### PR TITLE
Improve installer system checks and CLI verbosity

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -1,9 +1,11 @@
 """
 Core installer functionality for Open WebUI
 """
+
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
 from typing import Dict, Optional
@@ -11,31 +13,37 @@ from typing import Dict, Optional
 import docker
 import requests
 from rich.console import Console
+import logging
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
 class InstallerError(Exception):
     """Base exception for installer errors."""
+
     pass
 
 
 class SystemRequirementsError(InstallerError):
     """Exception for system requirement validation failures."""
+
     pass
 
 
 class Installer:
     """Main installer class for Open WebUI."""
 
-    def __init__(self):
+    def __init__(self, verbose: bool = False):
         """Initialize the installer."""
+        self.verbose = verbose
         self.docker_client = docker.from_env()
         self.webui_image = "ghcr.io/open-webui/open-webui:main"  # Default image
         self.config_dir = os.path.expanduser("~/.openwebui")
 
     def _check_system_requirements(self):
         """Validate system requirements."""
+        logger.debug("Validating system requirements")
         # Check macOS
         if platform.system() != "Darwin":
             raise SystemRequirementsError("This installer only supports macOS")
@@ -44,13 +52,24 @@ class Installer:
         if sys.version_info < (3, 9):
             raise SystemRequirementsError("Python 3.9 or higher is required")
 
-        # Check Docker
+        # Check Docker CLI
+        logger.debug("Checking Docker CLI availability")
+        if not shutil.which("docker"):
+            raise SystemRequirementsError(
+                "Docker is not installed. Install Docker with our script or from https://docs.docker.com/get-docker/"
+            )
+
+        # Check Docker service
+        logger.debug("Checking Docker service status")
         try:
             self.docker_client.ping()
-        except Exception:
-            raise SystemRequirementsError("Docker is not running or not installed")
+        except docker.errors.DockerException as e:
+            raise SystemRequirementsError(
+                "Docker service is not running. Start Docker Desktop and ensure the daemon is running."
+            ) from e
 
         # Check Ollama with timeout
+        logger.debug("Checking Ollama availability")
         try:
             response = requests.get("http://localhost:11434/api/tags", timeout=10)
             if response.status_code != 200:
@@ -64,9 +83,16 @@ class Installer:
         """Ensure configuration directory exists."""
         os.makedirs(self.config_dir, exist_ok=True)
 
-    def install(self, model: str = "llama2", port: int = 3000, force: bool = False, image: Optional[str] = None):
+    def install(
+        self,
+        model: str = "llama2",
+        port: int = 3000,
+        force: bool = False,
+        image: Optional[str] = None,
+    ):
         """Install Open WebUI."""
         try:
+            logger.debug("Starting installation")
             # Check if already installed
             if not force and self.get_status()["installed"]:
                 raise InstallerError("Open WebUI is already installed. Use --force to reinstall.")
@@ -99,7 +125,8 @@ class Installer:
             # Create launch script
             launch_script = os.path.join(self.config_dir, "launch-openwebui.sh")
             with open(launch_script, "w") as f:
-                f.write(f"""#!/bin/bash
+                f.write(
+                    f"""#!/bin/bash
 docker run -d \\
     --name open-webui \\
     -p {port}:8080 \\
@@ -107,7 +134,8 @@ docker run -d \\
     -e OLLAMA_API_BASE_URL=http://host.docker.internal:11434/api \\
     --add-host host.docker.internal:host-gateway \\
     {current_webui_image}
-""")
+"""
+                )
             os.chmod(launch_script, 0o755)
 
             # Create configuration file
@@ -135,14 +163,12 @@ docker run -d \\
                 container = self.docker_client.containers.run(
                     current_webui_image,
                     name="open-webui",
-                    ports={'8080/tcp': port},
+                    ports={"8080/tcp": port},
                     volumes={"open-webui": {"bind": "/app/backend/data", "mode": "rw"}},
-                    environment={
-                        "OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"
-                    },
+                    environment={"OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"},
                     extra_hosts={"host.docker.internal": "host-gateway"},
                     detach=True,
-                    restart_policy={"Name": "unless-stopped"}
+                    restart_policy={"Name": "unless-stopped"},
                 )
                 console.print(f"✓ Container started with ID: {container.short_id}")
 
@@ -155,6 +181,7 @@ docker run -d \\
     def uninstall(self):
         """Uninstall Open WebUI."""
         try:
+            logger.debug("Starting uninstallation")
             # Stop and remove container if running
             try:
                 container = self.docker_client.containers.get("open-webui")
@@ -165,6 +192,7 @@ docker run -d \\
 
             # Remove configuration
             import shutil
+
             if os.path.exists(self.config_dir):
                 shutil.rmtree(self.config_dir)
 
@@ -197,12 +225,14 @@ docker run -d \\
         try:
             with open(config_file) as f:
                 config = json.load(f)
-                status.update({
-                    "installed": True,
-                    "version": config.get("version"),
-                    "port": config.get("port"),
-                    "model": config.get("model"),
-                })
+                status.update(
+                    {
+                        "installed": True,
+                        "version": config.get("version"),
+                        "port": config.get("port"),
+                        "model": config.get("model"),
+                    }
+                )
         except Exception:
             return status
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for the CLI module
 """
+
 from unittest.mock import MagicMock, patch, Mock
 
 import pytest
@@ -9,10 +10,12 @@ from click.testing import CliRunner
 from openwebui_installer.cli import cli, install, uninstall, status
 from openwebui_installer.installer import InstallerError, SystemRequirementsError
 
+
 @pytest.fixture
 def runner():
     """Create a CLI test runner."""
     return CliRunner()
+
 
 @pytest.fixture
 def mock_installer():
@@ -22,45 +25,41 @@ def mock_installer():
         mock.return_value = installer
         yield installer
 
+
 def test_version(runner):
     """Test version command."""
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.output.lower()
 
+
 def test_install_success(runner, mock_installer):
     """Test successful installation."""
     result = runner.invoke(cli, ["install"])
     assert result.exit_code == 0
     mock_installer.install.assert_called_once_with(
-        model="llama2",
-        port=3000,
-        force=False,
-        image=None  # Added
+        model="llama2", port=3000, force=False, image=None  # Added
     )
+
 
 def test_install_with_options(runner, mock_installer):
     """Test installation with custom options."""
-    result = runner.invoke(cli, [
-        "install",
-        "--model", "codellama",
-        "--port", "8080",
-        "--force"
-    ])
+    result = runner.invoke(cli, ["install", "--model", "codellama", "--port", "8080", "--force"])
     assert result.exit_code == 0
     mock_installer.install.assert_called_once_with(
-        model="codellama",
-        port=8080,
-        force=True,
-        image=None  # Added
+        model="codellama", port=8080, force=True, image=None  # Added
     )
+
 
 def test_install_system_requirements_error(runner, mock_installer):
     """Test installation with system requirements error."""
-    mock_installer.install.side_effect = SystemRequirementsError("Docker not running")
+    mock_installer.install.side_effect = SystemRequirementsError(
+        "Docker service is not running. Start Docker Desktop and ensure the daemon is running."
+    )
     result = runner.invoke(cli, ["install"])
     assert result.exit_code == 1
-    assert "Docker not running" in result.output
+    assert "Docker service is not running" in result.output
+
 
 def test_install_error(runner, mock_installer):
     """Test installation with general error."""
@@ -69,11 +68,13 @@ def test_install_error(runner, mock_installer):
     assert result.exit_code == 1
     assert "Installation failed" in result.output
 
+
 def test_uninstall_success(runner, mock_installer):
     """Test successful uninstallation."""
     result = runner.invoke(cli, ["uninstall"], input="y\n")
     assert result.exit_code == 0
     mock_installer.uninstall.assert_called_once()
+
 
 def test_uninstall_abort(runner, mock_installer):
     """Test uninstallation abort."""
@@ -81,12 +82,14 @@ def test_uninstall_abort(runner, mock_installer):
     assert result.exit_code == 0
     mock_installer.uninstall.assert_not_called()
 
+
 def test_uninstall_error(runner, mock_installer):
     """Test uninstallation with error."""
     mock_installer.uninstall.side_effect = InstallerError("Uninstall failed")
     result = runner.invoke(cli, ["uninstall"], input="y\n")
     assert result.exit_code == 1
     assert "Uninstall failed" in result.output
+
 
 def test_status_not_installed(runner, mock_installer):
     """Test status command when not installed."""
@@ -100,6 +103,7 @@ def test_status_not_installed(runner, mock_installer):
     result = runner.invoke(cli, ["status"])
     assert result.exit_code == 0
     assert "not installed" in result.output.lower()
+
 
 def test_status_installed_not_running(runner, mock_installer):
     """Test status command when installed but not running."""
@@ -115,6 +119,7 @@ def test_status_installed_not_running(runner, mock_installer):
     assert "installed" in result.output.lower()
     assert "stopped" in result.output.lower()
 
+
 def test_status_installed_and_running(runner, mock_installer):
     """Test status command when installed and running."""
     mock_installer.get_status.return_value = {
@@ -129,12 +134,14 @@ def test_status_installed_and_running(runner, mock_installer):
     assert "installed" in result.output.lower()
     assert "running" in result.output.lower()
 
+
 def test_status_error(runner, mock_installer):
     """Test status command with error."""
     mock_installer.get_status.side_effect = InstallerError("Status check failed")
     result = runner.invoke(cli, ["status"])
     assert result.exit_code == 1
     assert "Status check failed" in result.output
+
 
 class TestCLI:
     def test_install_command(self, runner, mock_installer):
@@ -143,38 +150,41 @@ class TestCLI:
         result = runner.invoke(install)
         assert result.exit_code == 0
         assert "Installation complete!" in result.output
-        
+
         # mock_installer._check_system_requirements.assert_called_once() # This is an internal call of the real Installer.install, not directly by CLI
         mock_installer.install.assert_called_once()
-        
+
         # Test installation failure
         mock_installer.install.side_effect = InstallerError("Installation failed")
         result = runner.invoke(install)
         assert result.exit_code == 1
         assert "Error: Installation failed" in result.output
-        
+
     def test_uninstall_command(self, runner, mock_installer):
         """Test uninstall command"""
         # Test successful uninstallation
-        result = runner.invoke(uninstall, input="y\n") # Added input
+        result = runner.invoke(uninstall, input="y\n")  # Added input
         assert result.exit_code == 0
         assert "Uninstallation complete!" in result.output
-        
-        mock_installer.uninstall.assert_called_once() # Changed from cleanup
-        
+
+        mock_installer.uninstall.assert_called_once()  # Changed from cleanup
+
         # Test uninstallation failure
-        mock_installer.uninstall.reset_mock() # Reset mock
+        mock_installer.uninstall.reset_mock()  # Reset mock
         mock_installer.uninstall.side_effect = InstallerError("Uninstallation failed")
-        result = runner.invoke(uninstall, input="y\n") # Added input
+        result = runner.invoke(uninstall, input="y\n")  # Added input
         assert result.exit_code == 1
         assert "Error: Uninstallation failed" in result.output
-        
+
     def test_status_command(self, runner, mock_installer):
         """Test status command"""
         # Test when Open WebUI is running
-        mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
-            "model": "test", "running": True
+        mock_installer.get_status.return_value = {  # Use get_status
+            "installed": True,
+            "version": "0.1.0",
+            "port": 3000,
+            "model": "test",
+            "running": True,
         }
         result = runner.invoke(status)
         assert result.exit_code == 0
@@ -182,9 +192,12 @@ class TestCLI:
         assert "Status: Running" in result.output
 
         # Test when Open WebUI is not running
-        mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
-            "model": "test", "running": False
+        mock_installer.get_status.return_value = {  # Use get_status
+            "installed": True,
+            "version": "0.1.0",
+            "port": 3000,
+            "model": "test",
+            "running": False,
         }
         result = runner.invoke(status)
         assert result.exit_code == 0
@@ -192,45 +205,57 @@ class TestCLI:
         assert "Status: Stopped" in result.output
 
         # Test status check failure
-        mock_installer.get_status.side_effect = InstallerError("Status check failed") # Use get_status
+        mock_installer.get_status.side_effect = InstallerError(
+            "Status check failed"
+        )  # Use get_status
         result = runner.invoke(status)
         assert result.exit_code == 1
         assert "Error: Status check failed" in result.output
-        
+
     def test_version_option(self, runner):
         """Test --version option"""
-        from openwebui_installer import __version__ # Import to use in test
-        result = runner.invoke(cli, ['--version'])
+        from openwebui_installer import __version__  # Import to use in test
+
+        result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert f"cli, version {__version__}" in result.output # New
-        
+        assert f"cli, version {__version__}" in result.output  # New
+
     def test_help_option(self, runner):
         """Test --help option"""
-        result = runner.invoke(cli, ['--help'])
+        result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
-        assert 'Usage:' in result.output
-        assert 'Options:' in result.output
-        
+        assert "Usage:" in result.output
+        assert "Options:" in result.output
+
     def test_install_with_port_option(self, runner, mock_installer):
         """Test install command with custom port"""
-        result = runner.invoke(install, ['--port', '3001'])
+        result = runner.invoke(install, ["--port", "3001"])
         assert result.exit_code == 0
-        
+
         mock_installer.install.assert_called_once_with(
-            model='llama2', # Default from CLI
-            port=3001,      # Provided in test
-            force=False,    # Default from CLI
-            image=None      # Added
+            model="llama2",  # Default from CLI
+            port=3001,  # Provided in test
+            force=False,  # Default from CLI
+            image=None,  # Added
         )
-        
+
     def test_install_with_image_option(self, runner, mock_installer):
         """Test install command with custom image"""
-        result = runner.invoke(install, ['--image', 'custom/image:tag'])
+        result = runner.invoke(install, ["--image", "custom/image:tag"])
         assert result.exit_code == 0
-        
+
         mock_installer.install.assert_called_once_with(
-            model='llama2',      # Default from CLI
-            port=3000,         # Default from CLI
-            force=False,       # Default from CLI
-            image='custom/image:tag' # Provided in test
+            model="llama2",  # Default from CLI
+            port=3000,  # Default from CLI
+            force=False,  # Default from CLI
+            image="custom/image:tag",  # Provided in test
         )
+
+    def test_verbose_flag(self, runner):
+        """Installer receives verbose flag when provided"""
+        with patch("openwebui_installer.cli.Installer") as mock_cls:
+            instance = Mock()
+            mock_cls.return_value = instance
+            result = runner.invoke(cli, ["--verbose", "install"])
+            assert result.exit_code == 0
+            mock_cls.assert_called_with(verbose=True)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,7 @@
 """
 Tests for the installer module
 """
+
 import json
 import platform
 import shutil
@@ -9,19 +10,18 @@ from unittest.mock import MagicMock, mock_open
 
 import docker
 import pytest
-from openwebui_installer.installer import (Installer, InstallerError,
-                                           SystemRequirementsError)
+from openwebui_installer.installer import Installer, InstallerError, SystemRequirementsError
 
 
 @pytest.fixture
-def installer(tmp_path, mocker): # Added mocker
+def installer(tmp_path, mocker):  # Added mocker
     """Fixture to create a test installer instance with a mocked config directory."""
     config_dir = tmp_path / "openwebui"
     config_dir.mkdir()
 
     # Patch docker.from_env() before Installer is instantiated
     mock_docker_client = MagicMock()
-    mocker.patch('docker.from_env', return_value=mock_docker_client)
+    mocker.patch("docker.from_env", return_value=mock_docker_client)
 
     installer_instance = Installer()
     installer_instance.config_dir = str(config_dir)
@@ -35,10 +35,10 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_success(self, installer, mocker):
         """Test that system requirements check passes on macOS with Docker and Ollama running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
         installer.docker_client.ping.return_value = True
-        mock_requests_get = mocker.patch('requests.get')
+        mock_requests_get = mocker.patch("requests.get")
         mock_requests_get.return_value.status_code = 200
 
         # This should not raise any exception
@@ -46,32 +46,34 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_wrong_os(self, installer, mocker):
         """Test that system requirements check fails on a non-macOS system."""
-        mocker.patch('platform.system', return_value='Linux')
+        mocker.patch("platform.system", return_value="Linux")
         with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):
         """Test that system requirements check fails on an old Python version."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 8, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 8, 0))
         with pytest.raises(SystemRequirementsError, match="Python 3.9 or higher is required"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_docker_not_running(self, installer, mocker):
         """Test that system requirements check fails if Docker is not running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
-        installer.docker_client.ping.side_effect = Exception("Docker not running")
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
+        installer.docker_client.ping.side_effect = docker.errors.DockerException(
+            "Docker not running"
+        )
 
-        with pytest.raises(SystemRequirementsError, match="Docker is not running or not installed"):
+        with pytest.raises(SystemRequirementsError, match="Docker service is not running"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_ollama_not_running(self, installer, mocker):
         """Test that system requirements check fails if Ollama is not running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
         installer.docker_client.ping.return_value = True
-        mock_requests_get = mocker.patch('requests.get')
+        mock_requests_get = mocker.patch("requests.get")
         mock_requests_get.side_effect = Exception("Connection failed")
 
         with pytest.raises(SystemRequirementsError, match="Ollama is not installed or not running"):
@@ -79,31 +81,33 @@ class TestInstallerSuite:
 
     def test_install_full_run_success(self, installer, mocker):
         """Test a complete, successful installation run from a clean state."""
-        mocker.patch.object(installer, '_check_system_requirements')
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mock_open_patch = mocker.patch('builtins.open', mock_open())
-        mocker.patch('os.makedirs')
-        mock_json_dump = mocker.patch('json.dump')
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mocker.patch('os.chmod')
+        mocker.patch.object(installer, "_check_system_requirements")
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mock_open_patch = mocker.patch("builtins.open", mock_open())
+        mocker.patch("os.makedirs")
+        mock_json_dump = mocker.patch("json.dump")
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mocker.patch("os.chmod")
 
         installer.install(model="test-model", port=1234, force=False)
 
         installer._check_system_requirements.assert_called_once()
         installer.docker_client.images.pull.assert_called_with(installer.webui_image)
-        mock_subprocess_run.assert_called_with(["ollama", "pull", "test-model"], check=True, timeout=300)
-        assert mock_json_dump.call_args[0][0]['port'] == 1234
-        assert mock_json_dump.call_args[0][0]['model'] == "test-model"
+        mock_subprocess_run.assert_called_with(
+            ["ollama", "pull", "test-model"], check=True, timeout=300
+        )
+        assert mock_json_dump.call_args[0][0]["port"] == 1234
+        assert mock_json_dump.call_args[0][0]["model"] == "test-model"
 
     def test_install_with_custom_image(self, installer, mocker):
         """Test installation with a custom Docker image."""
-        mocker.patch.object(installer, '_check_system_requirements')
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mock_open_patch = mocker.patch('builtins.open', mock_open())
-        mocker.patch('os.makedirs')
-        mock_json_dump = mocker.patch('json.dump')
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mocker.patch('os.chmod')
+        mocker.patch.object(installer, "_check_system_requirements")
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mock_open_patch = mocker.patch("builtins.open", mock_open())
+        mocker.patch("os.makedirs")
+        mock_json_dump = mocker.patch("json.dump")
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mocker.patch("os.chmod")
 
         custom_image = "custom/open-webui:latest"
         installer.install(model="test-model", port=1234, force=False, image=custom_image)
@@ -111,18 +115,20 @@ class TestInstallerSuite:
         installer.docker_client.images.pull.assert_called_with(custom_image)
         # Check that custom image is stored in config
         config_data = mock_json_dump.call_args[0][0]
-        assert config_data['image'] == custom_image
+        assert config_data["image"] == custom_image
 
     def test_install_stops_if_already_installed_without_force(self, installer, mocker):
         """Test that installation stops if already installed and force=False."""
-        mocker.patch.object(installer, 'get_status', return_value={'installed': True})
-        with pytest.raises(InstallerError, match="Open WebUI is already installed. Use --force to reinstall."):
+        mocker.patch.object(installer, "get_status", return_value={"installed": True})
+        with pytest.raises(
+            InstallerError, match="Open WebUI is already installed. Use --force to reinstall."
+        ):
             installer.install(force=False)
 
     def test_uninstall_success(self, installer, mocker):
         """Test a successful uninstall removes container, volume, and config directory."""
-        mock_rmtree = mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True)
+        mock_rmtree = mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)
 
         mock_container = MagicMock()
         mock_volume = MagicMock()
@@ -139,8 +145,8 @@ class TestInstallerSuite:
 
     def test_uninstall_container_and_volume_not_found(self, installer, mocker):
         """Test uninstall when container and volume don't exist."""
-        mock_rmtree = mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True)
+        mock_rmtree = mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)
 
         installer.docker_client.containers.get.side_effect = docker.errors.NotFound("not found")
         installer.docker_client.volumes.get.side_effect = docker.errors.NotFound("not found")
@@ -151,15 +157,15 @@ class TestInstallerSuite:
 
     def test_get_status_not_installed(self, installer, mocker):
         """Test get_status correctly reports not installed when config dir is missing."""
-        mocker.patch('os.path.exists', return_value=False)
+        mocker.patch("os.path.exists", return_value=False)
         status = installer.get_status()
         assert not status["installed"]
 
     def test_get_status_installed_and_running(self, installer, mocker):
         """Test get_status reports correctly when installed and the container is running."""
         mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
-        mocker.patch('builtins.open', mock_open(read_data=mock_file_content))
-        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+        mocker.patch("os.path.exists", return_value=True)
 
         mock_container = MagicMock()
         mock_container.status = "running"
@@ -174,8 +180,8 @@ class TestInstallerSuite:
     def test_get_status_installed_not_running(self, installer, mocker):
         """Test get_status reports correctly when installed but the container is not running."""
         mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
-        mocker.patch('builtins.open', mock_open(read_data=mock_file_content))
-        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+        mocker.patch("os.path.exists", return_value=True)
 
         installer.docker_client.containers.get.side_effect = docker.errors.NotFound("not found")
 
@@ -185,19 +191,23 @@ class TestInstallerSuite:
 
     def test_ensure_config_dir(self, installer, mocker):
         """Test that config directory is created."""
-        mock_makedirs = mocker.patch('os.makedirs')
+        mock_makedirs = mocker.patch("os.makedirs")
         installer._ensure_config_dir()
         mock_makedirs.assert_called_once_with(installer.config_dir, exist_ok=True)
 
     def test_pull_open_webui_failure(self, installer, mocker):
         """Test error handling when pulling the webui image fails during install."""
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mocker.patch.object(installer, '_check_system_requirements') # Mock to prevent its execution
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mocker.patch.object(
+            installer, "_check_system_requirements"
+        )  # Mock to prevent its execution
         # installer.docker_client is already a MagicMock from the fixture.
         installer.docker_client.images.pull.side_effect = docker.errors.APIError("pull failed")
 
-        with pytest.raises(InstallerError, match="Failed to pull Open WebUI Docker image: pull failed"):
-            installer.install(force=False) # Call install, which contains the pull logic
+        with pytest.raises(
+            InstallerError, match="Failed to pull Open WebUI Docker image: pull failed"
+        ):
+            installer.install(force=False)  # Call install, which contains the pull logic
 
     # def test_start_open_webui(self, installer, mocker):
     #     """Test starting Open WebUI container."""
@@ -220,31 +230,35 @@ class TestInstallerSuite:
     def test_pull_ollama_model_failure(self, installer, mocker):
         """Test error handling when pulling an Ollama model fails during install."""
         model_name = "test-model"
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mocker.patch.object(installer, '_check_system_requirements')
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mocker.patch.object(installer, "_check_system_requirements")
         # Mock the docker image pull to prevent it from running
         installer.docker_client.images.pull.return_value = None
 
         # Mock subprocess.run to fail for the ollama pull
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, ["ollama", "pull", model_name])
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            1, ["ollama", "pull", model_name]
+        )
 
         expected_error_message = f"Failed to pull Ollama model {model_name}"
         with pytest.raises(InstallerError, match=expected_error_message):
             installer.install(model=model_name, force=False)
 
         # Ensure subprocess.run was called with the correct model
-        mock_subprocess_run.assert_called_with(["ollama", "pull", model_name], check=True, timeout=300)
+        mock_subprocess_run.assert_called_with(
+            ["ollama", "pull", model_name], check=True, timeout=300
+        )
 
-    def test_stop_open_webui(self, installer, mocker): # Renaming to reflect what it does
+    def test_stop_open_webui(self, installer, mocker):  # Renaming to reflect what it does
         """Test that uninstall stops and removes the container."""
         # installer.docker_client is already a MagicMock from the fixture
         mock_container = MagicMock(name="mock_container")
         installer.docker_client.containers.get.return_value = mock_container
 
         # Mock other parts of uninstall to isolate container stopping
-        mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True) # Assume config dir exists
+        mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)  # Assume config dir exists
         installer.docker_client.volumes.get.return_value = MagicMock(name="mock_volume")
 
         installer.uninstall()


### PR DESCRIPTION
## Summary
- refine Docker checks with install/runtime hints
- enable `--verbose` CLI flag
- update CLI to forward verbose mode
- adjust tests for new error messages and flag

## Testing
- `black openwebui_installer/cli.py openwebui_installer/installer.py tests/test_cli.py tests/test_installer.py -q`
- `flake8 openwebui_installer/cli.py openwebui_installer/installer.py tests/test_cli.py tests/test_installer.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6858009496c48326bb6d9b1e6d9dffcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global `--verbose` flag to the CLI for enhanced debug output and detailed logging across all commands.

- **Bug Fixes**
  - Improved error messages for system requirement checks, especially regarding Docker service status.

- **Style**
  - Standardized string formatting and improved code readability in test suites.

- **Tests**
  - Added tests to verify the new verbose mode and updated existing tests for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->