### PR TITLE
Enable brew upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ brew install openwebui-installer
 openwebui-installer install
 ```
 
+To upgrade later, run:
+
+```bash
+brew update
+brew upgrade openwebui-installer
+```
+
 ## 🔧 Container Management
 
 ```bash

--- a/homebrew-tap/Formula/openwebui-installer.rb
+++ b/homebrew-tap/Formula/openwebui-installer.rb
@@ -5,7 +5,13 @@ class OpenwebuiInstaller < Formula
   homepage "https://github.com/open-webui/openwebui-installer"
   url "https://github.com/open-webui/openwebui-installer/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "placeholder" # Will be updated by CI
+  version "0.1.0"
   license "MIT"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   depends_on "python@3.9"
 

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -20,6 +20,15 @@ Then install the desired formula:
 brew install openwebui-installer
 ```
 
+### Upgrading
+
+To upgrade `openwebui-installer` to the latest release, run:
+
+```bash
+brew update
+brew upgrade openwebui-installer
+```
+
 ## Development
 
 The formulae in this tap are automatically updated by GitHub Actions when new releases are published.


### PR DESCRIPTION
## Summary
- add explicit upgrade section in Homebrew instructions
- update formula with livecheck to enable `brew upgrade`
- document upgrade steps in Homebrew tap README

## Testing
- `flake8 --exclude build .` *(fails: E501 lines too long etc.)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6858036a4a2c83268364d4dadaaa9c01