### PR TITLE
Improve Qt test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
@@ -26,10 +27,33 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+
+    - name: Install Qt system packages (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          xvfb libegl1 libegl1-mesa-dev libgl1 \
+          libxkbcommon-x11-0 libxcomposite1 libxrandr2 \
+          libxdamage1 libxi6 libxtst6 libglu1-mesa \
+          libglib2.0-0 libxshmfence1 libxrender1
+
+    - name: Install Qt system packages (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install qt pyqt6
+
+    - name: Start Xvfb (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        Xvfb :99 -screen 0 1920x1080x24 > /tmp/Xvfb.log 2>&1 &
         
     - name: Run tests
       run: |
         pytest tests/ --cov=openwebui_installer --cov-report=xml
+      env:
+        DISPLAY: ":99"
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
- run tests on macOS and Linux
- install Qt dependencies and start Xvfb for Linux
- run tests with DISPLAY=:99

## Testing
- `pytest tests/ --cov=openwebui_installer --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_6858097da78c8326ae55d93faf0df2aa