### PR TITLE
Convert install.py to CLI wrapper

### DIFF
--- a/CODEBASE_EVALUATION.md
+++ b/CODEBASE_EVALUATION.md
@@ -16,7 +16,7 @@ openwebui-installer/
 │   ├── cli.py                   # Click-based CLI
 │   ├── gui.py                   # GUI components (unused)
 │   └── installer.py             # Core Docker management
-├── install.py                   # Simple entry point script
+├── install.py                   # Wrapper invoking openwebui_installer CLI
 ├── setup.sh                     # Bash-based setup script
 ├── .github/workflows/release.yml # Automated releases
 ├── scripts/test_installation.sh # Testing framework

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ brew install openwebui-installer
 openwebui-installer install
 ```
 
+You can also invoke the installer with Python if you prefer:
+
+```bash
+python3 install.py install
+```
+
+The `install.py` script simply delegates to the same command-line interface.
+
 ## 🔧 Container Management
 
 ```bash
@@ -152,7 +160,7 @@ After each release, you'll need to update your public Homebrew tap:
 - **`.github/workflows/release.yml`** - Automated release workflow
 - **`setup.sh`** - Interactive setup script
 - **`README.md`** - This file
-- **Sample files** - Created if not present (README.md, install.py, LICENSE)
+- **Sample files** - Created if not present (README.md, install.py wrapper, LICENSE)
 
 ## 🔧 Workflow Features
 

--- a/install.py
+++ b/install.py
@@ -1,56 +1,13 @@
 #!/usr/bin/env python3
+"""Compatibility entry point for invoking the installer via ``install.py``.
+
+The official command line interface lives in :mod:`openwebui_installer.cli`.
+This thin wrapper simply delegates to that entry point so existing scripts
+calling ``python install.py`` continue to work.
 """
-Open WebUI Installer
-Easy installer and manager for Open WebUI
-"""
 
-import sys
-import argparse
-import subprocess
-import os
+from openwebui_installer.cli import main
 
-def main():
-    parser = argparse.ArgumentParser(description='Open WebUI Installer')
-    parser.add_argument('command', nargs='?', default='help',
-                       choices=['install', 'start', 'stop', 'status', 'update', 'uninstall', 'help'],
-                       help='Command to execute')
-    parser.add_argument('--version', action='version', version='1.1.1')
 
-    args = parser.parse_args()
-
-    if args.command == 'help':
-        parser.print_help()
-        print("\nAvailable commands:")
-        print("  install     Install Open WebUI")
-        print("  start       Start Open WebUI service")
-        print("  stop        Stop Open WebUI service")
-        print("  status      Check service status")
-        print("  update      Update Open WebUI")
-        print("  uninstall   Remove Open WebUI")
-    elif args.command == 'install':
-        print("🚀 Installing Open WebUI...")
-        # Add your installation logic here
-        print("✅ Installation completed!")
-    elif args.command == 'start':
-        print("▶️  Starting Open WebUI...")
-        # Add your start logic here
-        print("✅ Open WebUI started!")
-    elif args.command == 'stop':
-        print("⏹️  Stopping Open WebUI...")
-        # Add your stop logic here
-        print("✅ Open WebUI stopped!")
-    elif args.command == 'status':
-        print("📊 Checking Open WebUI status...")
-        # Add your status logic here
-        print("✅ Open WebUI is running")
-    elif args.command == 'update':
-        print("🔄 Updating Open WebUI...")
-        # Add your update logic here
-        print("✅ Update completed!")
-    elif args.command == 'uninstall':
-        print("🗑️  Uninstalling Open WebUI...")
-        # Add your uninstall logic here
-        print("✅ Uninstall completed!")
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- simplify `install.py` to delegate to `openwebui_installer.cli`
- document the wrapper in README and codebase evaluation

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6858097ca5e08326873c15ec282b4670