### PR TITLE
Add Qt setup and Xvfb to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
@@ -26,9 +27,35 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+
+    - name: Install Qt packages
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          qtbase5-dev \
+          qt5-qmake \
+          xvfb \
+          libegl1 \
+          libegl-mesa0 \
+          libgl1-mesa-dev \
+          libgl1-mesa-dri \
+          libglib2.0-0 \
+          libsm6 \
+          libxext6 \
+          libxkbcommon-x11-0 \
+          libxrender1 \
+          libxcb-xinerama0
+
+    - name: Start Xvfb
+      if: runner.os == 'Linux'
+      run: |
+        sudo Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
         
     - name: Run tests
       run: |
+        export DISPLAY=:99
+        export QT_QPA_PLATFORM=offscreen
         pytest tests/ --cov=openwebui_installer --cov-report=xml
         
     - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
- expand test matrix to run on Linux and macOS
- install Qt related system packages on Linux runners
- start Xvfb for headless tests and set `DISPLAY`
- run tests with `QT_QPA_PLATFORM=offscreen`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580c304b4083268dd00fc208e40fab