### PR TITLE
Add Codex setup script and docs

### DIFF
--- a/.codexrc
+++ b/.codexrc
@@ -1,0 +1,6 @@
+test: xvfb-run -a pytest -q
+lint:
+  - black --check .
+  - isort --check-only .
+  - flake8 .
+build: python -m build

--- a/CODEX_SETUP.md
+++ b/CODEX_SETUP.md
@@ -1,0 +1,19 @@
+# Codex Environment Setup
+
+The `codex-setup.sh` script prepares the development environment for running automated tests with Codex.
+
+## Usage
+
+1. Run the setup script:
+   ```bash
+   ./codex-setup.sh
+   ```
+2. The script installs Qt build dependencies using `apt-get` on Linux or Homebrew on macOS.
+3. Python dependencies are installed from PyPI. If network access fails, place pre-built wheels in a `wheelhouse/` directory and rerun the script.
+4. An Xvfb display is started on `:99` for headless PyQt tests.
+5. The commands used by Codex are stored in `.codexrc`:
+   - **Tests**: `xvfb-run -a pytest -q`
+   - **Lint**: `black --check .`, `isort --check-only .`, `flake8 .`
+   - **Build**: `python -m build`
+
+After running `codex-setup.sh`, the environment is ready for running tests or CI workflows that rely on a virtual display.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ docker rm open-webui
 
 - [Working Setup Guide](WORKING_SETUP.md) - Detailed troubleshooting and setup notes
 - [Release Notes](CHANGELOG.md) - Version history and changes
+- [Codex Setup](CODEX_SETUP.md) - Prepare the environment for automated tests
 
 ---
 

--- a/codex-setup.sh
+++ b/codex-setup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# codex-setup.sh - Prepare Codex environment for Open WebUI Installer
+# Installs Qt dependencies, Python packages and starts Xvfb for headless testing.
+
+set -euo pipefail
+
+install_qt_deps() {
+    echo "Installing Qt dependencies..."
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update -y
+        sudo apt-get install -y libx11-dev libgl1-mesa-dev xvfb
+    elif command -v brew >/dev/null 2>&1; then
+        brew update
+        brew install qt xorg-server || true
+    else
+        echo "Unsupported OS. Install libx11, mesa, and Xvfb manually." >&2
+    fi
+}
+
+install_python_packages() {
+    echo "Installing Python packages..."
+    if pip install -r requirements.txt -r requirements-dev.txt; then
+        return 0
+    fi
+    echo "Online install failed, attempting offline install from wheelhouse/"
+    if [ -d wheelhouse ]; then
+        pip install wheelhouse/*.whl
+    else
+        echo "wheelhouse directory not found. Cannot perform offline install." >&2
+        exit 1
+    fi
+}
+
+start_xvfb() {
+    if pgrep Xvfb >/dev/null 2>&1; then
+        return
+    fi
+    echo "Starting Xvfb on :99..."
+    Xvfb :99 -screen 0 1024x768x24 &
+    export DISPLAY=:99
+}
+
+install_qt_deps
+install_python_packages
+start_xvfb
+
+echo "Codex environment ready."


### PR DESCRIPTION
## Summary
- add `codex-setup.sh` to install Qt packages and start Xvfb
- support offline wheel installs
- add `.codexrc` with test, lint and build commands
- document workflow in `CODEX_SETUP.md`
- reference the new guide from `README.md`

## Testing
- `xvfb-run -a pytest -q` *(fails: unrecognized arguments)*
- `flake8 .` *(fails: style violations)*
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68580c282da88326a5e86f16cfb32bc5