### PR TITLE
Fix GUI test imports

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,7 +4,14 @@ Tests for the GUI module
 import sys
 from unittest.mock import patch, MagicMock
 import pytest
-from PyQt6.QtWidgets import QApplication, QMessageBox
+# Skip GUI tests if PyQt6 or required system libraries are unavailable
+try:
+    from PyQt6.QtWidgets import QApplication, QMessageBox
+except Exception:  # pragma: no cover - platform specific
+    pytest.skip(
+        "PyQt6 is not available; skipping GUI tests",
+        allow_module_level=True,
+    )
 from openwebui_installer.gui import MainWindow
 from openwebui_installer import __version__
 


### PR DESCRIPTION
## Summary
- skip GUI test suite when PyQt6 is unavailable

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_mock -p pytest_cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68580d8dbfc483269f93fb925140773d