### PR TITLE
Add macOS DMG build and signing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.extract_version.outputs.VERSION }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -244,3 +247,41 @@ jobs:
         echo "2. 🔄 Update Homebrew formula with the SHA256 hash above"
         echo "3. 🧪 Test the installation"
         echo "4. 📢 Announce the release!"
+
+  build_dmg:
+    needs: release
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Import signing certificate
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Build and notarize DMG
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: scripts/build_dmg.sh
+
+      - name: Upload DMG
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: dist/OpenWebUIInstaller-${{ needs.release.outputs.version }}.dmg
+          asset_name: openwebui-installer-${{ needs.release.outputs.version }}.dmg
+          asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ brew install openwebui-installer
 openwebui-installer install
 ```
 
+### Method 3: Signed DMG
+
+Releases include a notarized DMG for macOS users. Download the latest `.dmg` file
+from GitHub Releases and drag the **OpenWebUIInstaller.app** to your
+Applications folder.
+
 ## 🔧 Container Management
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,9 +20,15 @@ The following secrets must be configured in GitHub repository settings:
 
 2. `HOMEBREW_TAP_TOKEN`: GitHub Personal Access Token
    - Generate at: https://github.com/settings/tokens
-   - Required scopes: 
+   - Required scopes:
      * `repo` (Full control of private repositories)
      * `workflow` (Update GitHub Action workflows)
+3. `APPLE_CERTIFICATE_P12`: Base64 encoded signing certificate
+4. `APPLE_CERTIFICATE_PASSWORD`: Password for the certificate
+5. `CODESIGN_IDENTITY`: Signing identity name
+6. `APPLE_ID`: Apple ID used for notarization
+7. `APPLE_PASSWORD`: App-specific password for notarization
+8. `APPLE_TEAM_ID`: Apple Developer team ID
 
 ## Release Steps
 
@@ -48,6 +54,7 @@ The following secrets must be configured in GitHub repository settings:
      3. Create GitHub Release
      4. Publish to PyPI
      5. Update Homebrew formula
+     6. Build, sign, and notarize the DMG
 
 4. **Verify Release**
    - Check GitHub release page
@@ -57,6 +64,7 @@ The following secrets must be configured in GitHub repository settings:
      brew update
      brew install openwebui-installer
      ```
+   - Download and mount the DMG to confirm it is signed and opens correctly
 
 ## Troubleshooting
 

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="OpenWebUIInstaller"
+VERSION="${VERSION:-0.1.0}"
+DMG_NAME="${APP_NAME}-${VERSION}.dmg"
+
+BUILD_DIR="dist"
+APP_PATH="$BUILD_DIR/${APP_NAME}.app"
+
+function build_app() {
+    python -m pip install --upgrade pip
+    pip install pyinstaller
+    pyinstaller --noconfirm --windowed --name "$APP_NAME" openwebui_installer/gui.py
+}
+
+function sign_app() {
+    codesign --deep --force --options runtime \
+        --sign "$CODESIGN_IDENTITY" "$APP_PATH"
+}
+
+function create_dmg() {
+    brew install create-dmg || true
+    create-dmg --overwrite --volname "$APP_NAME" "$APP_PATH" "$BUILD_DIR/$DMG_NAME"
+}
+
+function notarize_dmg() {
+    xcrun notarytool submit "$BUILD_DIR/$DMG_NAME" \
+        --apple-id "$APPLE_ID" \
+        --team-id "$APPLE_TEAM_ID" \
+        --password "$APPLE_PASSWORD" \
+        --wait
+    xcrun stapler staple "$BUILD_DIR/$DMG_NAME"
+}
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "DMG build only supported on macOS" >&2
+    exit 1
+fi
+
+mkdir -p "$BUILD_DIR"
+
+build_app
+sign_app
+create_dmg
+notarize_dmg
+
+echo "Created notarized DMG: $BUILD_DIR/$DMG_NAME"


### PR DESCRIPTION
## Summary
- support DMG generation via new `build_dmg.sh`
- build notarized DMG in GitHub Actions
- document new secrets and workflow steps
- mention DMG distribution in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685810a6986c8326b6209a28ff81a52f