### PR TITLE
Add notarization step for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.extract_version.outputs.VERSION }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -182,10 +185,16 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        upload_url: ${{ needs.release.outputs.upload_url }}
         asset_path: ./release/openwebui-installer-${{ steps.extract_version.outputs.VERSION }}.tar.gz
         asset_name: openwebui-installer-${{ steps.extract_version.outputs.VERSION }}.tar.gz
         asset_content_type: application/gzip
+
+    - name: Save archive for notarization
+      uses: actions/upload-artifact@v3
+      with:
+        name: installer-archive
+        path: ./release/openwebui-installer-${{ steps.extract_version.outputs.VERSION }}.tar.gz
 
     - name: Generate SHA256 for Homebrew
       run: |
@@ -244,3 +253,36 @@ jobs:
         echo "2. 🔄 Update Homebrew formula with the SHA256 hash above"
         echo "3. 🧪 Test the installation"
         echo "4. 📢 Announce the release!"
+
+  notarize:
+    needs: release
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download packaged installer
+      uses: actions/download-artifact@v3
+      with:
+        name: installer-archive
+
+    - name: Run installer verification
+      run: bash scripts/test_installation.sh
+
+    - name: Notarize installer
+      run: bash scripts/notarize.sh openwebui-installer-${{ needs.release.outputs.version }}.tar.gz
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        DEVELOPER_ID_APP: ${{ secrets.DEVELOPER_ID_APP }}
+
+    - name: Upload notarized artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: notarized-openwebui-installer-${{ needs.release.outputs.version }}.tar.gz
+        asset_name: openwebui-installer-${{ needs.release.outputs.version }}-notarized.tar.gz
+        asset_content_type: application/gzip

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# notarize.sh - Sign and notarize Open WebUI installer archive
+# Works on macOS; fails on other platforms
+set -euo pipefail
+
+ARCHIVE="${1:-}"
+if [[ -z "$ARCHIVE" ]]; then
+  echo "Usage: $0 <archive>" >&2
+  exit 1
+fi
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Notarization must run on macOS" >&2
+  exit 1
+fi
+
+SIGN_ID="${DEVELOPER_ID_APP:?DEVELOPER_ID_APP not set}"
+APPLE_ID="${APPLE_ID:?APPLE_ID not set}"
+TEAM_ID="${APPLE_TEAM_ID:?APPLE_TEAM_ID not set}"
+APP_PW="${APPLE_APP_SPECIFIC_PASSWORD:?APPLE_APP_SPECIFIC_PASSWORD not set}"
+
+SIGNED="signed-$ARCHIVE"
+cp "$ARCHIVE" "$SIGNED"
+
+echo "Signing $SIGNED..."
+codesign --deep --force --options runtime --sign "$SIGN_ID" "$SIGNED"
+
+echo "Submitting $SIGNED for notarization..."
+xcrun notarytool submit "$SIGNED" \
+  --apple-id "$APPLE_ID" \
+  --team-id "$TEAM_ID" \
+  --password "$APP_PW" \
+  --wait
+
+echo "Stapling notarization ticket..."
+xcrun stapler staple "$SIGNED"
+
+mv "$SIGNED" "notarized-$ARCHIVE"
+echo "Created notarized artifact notarized-$ARCHIVE"


### PR DESCRIPTION
## Summary
- save installer archive as artifact for later notarization
- add macOS job that tests installer and notarizes the archive
- script to sign and notarize installer archive

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -k 'not gui'`
- `flake8 .`
- `shellcheck scripts/notarize.sh`


------
https://chatgpt.com/codex/tasks/task_e_6858110629e48326bef99ba01ae85abe