### PR TITLE
Extend installer OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then access: **http://localhost:3000**
 
 - Docker Desktop installed and running
 - Web browser
+- macOS or Linux system (Windows users can run within WSL)
 
 ## 🚀 Installation Methods
 

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -36,9 +36,20 @@ class Installer:
 
     def _check_system_requirements(self):
         """Validate system requirements."""
-        # Check macOS
-        if platform.system() != "Darwin":
-            raise SystemRequirementsError("This installer only supports macOS")
+        system = platform.system()
+
+        # Allow macOS and Linux natively. On Windows, require WSL.
+        if system == "Windows":
+            # Detect WSL via environment variables or kernel release string
+            if (
+                "WSL_DISTRO_NAME" not in os.environ
+                and "microsoft" not in platform.release().lower()
+            ):
+                raise SystemRequirementsError("Windows is only supported via WSL")
+        elif system not in ("Darwin", "Linux"):
+            raise SystemRequirementsError(
+                f"Unsupported operating system: {system}"
+            )
 
         # Check Python version (aligned with setup.py)
         if sys.version_info < (3, 9):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -34,8 +34,8 @@ class TestInstallerSuite:
     """A comprehensive and corrected test suite for the Installer class."""
 
     def test_check_system_requirements_success(self, installer, mocker):
-        """Test that system requirements check passes on macOS with Docker and Ollama running."""
-        mocker.patch('platform.system', return_value='Darwin')
+        """Test that system requirements check passes on Linux with Docker and Ollama running."""
+        mocker.patch('platform.system', return_value='Linux')
         mocker.patch('sys.version_info', (3, 9, 0))
         installer.docker_client.ping.return_value = True
         mock_requests_get = mocker.patch('requests.get')
@@ -45,9 +45,9 @@ class TestInstallerSuite:
         installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_os(self, installer, mocker):
-        """Test that system requirements check fails on a non-macOS system."""
-        mocker.patch('platform.system', return_value='Linux')
-        with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
+        """Test that system requirements check fails on an unsupported operating system."""
+        mocker.patch('platform.system', return_value='FreeBSD')
+        with pytest.raises(SystemRequirementsError, match="Unsupported operating system"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):


### PR DESCRIPTION
## Summary
- update `_check_system_requirements` to allow Linux and WSL
- document OS support in README
- update tests for new behavior

## Testing
- `pip install -r requirements-dev.txt`
- `pip uninstall -y openwebui-installer`
- `pip install -e .`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581801624483269fe486f88d726ef2