### PR TITLE
Install dev deps in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # requirements-dev.txt includes requirements.txt
+          pip install -r requirements-dev.txt
         
-    - name: Run tests
-      run: |
-        pytest tests/ --cov=openwebui_installer --cov-report=xml
+      - name: Run tests
+        run: |
+          # Rely on pytest configuration in pyproject.toml for coverage settings
+          pytest --cov-report=xml
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 pytest>=7.0.0
-pytest-cov>=3.0.0
+pytest-cov>=6.2.1
 pytest-qt>=4.2.0
 pytest-mock>=3.10.0
 black>=22.0.0


### PR DESCRIPTION
## Summary
- update pytest-cov in dev requirements
- update CI to install development dependencies via requirements-dev.txt
- run pytest using configuration without repeating coverage options

## Testing
- `pip install -r requirements-dev.txt`
- `pytest --cov-report=xml` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685817f64c948326a7b51c804438a3fc