### PR TITLE
Fix status label text update

### DIFF
--- a/openwebui_installer/gui.py
+++ b/openwebui_installer/gui.py
@@ -125,11 +125,15 @@ class MainWindow(QMainWindow):
 
             if status["installed"]:
                 self.status_label.setText(
-                    f"Open WebUI is installed\n"
-                    f"Version: {status['version']}\n"
-                    f"Port: {status['port']}\n"
-                    f"Model: {status['model']}\n"
-                    f"Status: {'Running' if status['running'] else 'Stopped'}"
+                    "\n".join(
+                        [
+                            "Open WebUI is installed",
+                            f"Version: {status['version']}",
+                            f"Port: {status['port']}",
+                            f"Model: {status['model']}",
+                            f"Status: {'Running' if status['running'] else 'Stopped'}",
+                        ]
+                    )
                 )
                 self.status_label.show()
                 self.install_button.setText("Reinstall")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -142,3 +142,35 @@ def test_uninstall_with_error(window):
                     warning_args = mock_warning.call_args[0]
                     assert "Could not uninstall" in warning_args[2]  # message is third argument
                     mock_update.assert_called_once()
+
+
+@patch("openwebui_installer.gui.Installer")
+def test_update_status_label_text(mock_installer_class, qapp):
+    """Test the status label text when the application is installed."""
+    status = {
+        "installed": True,
+        "version": "1.2.3",
+        "port": 1234,
+        "model": "llama2",
+        "running": False,
+    }
+
+    mock_installer_instance = mock_installer_class.return_value
+    mock_installer_instance.get_status.return_value = status
+
+    win = MainWindow()
+    qapp.processEvents()
+
+    expected_text = "\n".join(
+        [
+            "Open WebUI is installed",
+            f"Version: {status['version']}",
+            f"Port: {status['port']}",
+            f"Model: {status['model']}",
+            "Status: Stopped",
+        ]
+    )
+
+    assert win.status_label.text() == expected_text
+    win.close()
+    qapp.processEvents()


### PR DESCRIPTION
## Summary
- render status text in a single `setText` call using `"\n".join`
- test that the status label shows the joined string when installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582915cfd48326987fbd925e2f69ea