### PR TITLE
Add Linux support for installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Easy installer and manager for Open WebUI - User-friendly AI Interface
 
+Supported Platforms: **macOS**, **Linux**, and **Windows (via WSL)**
+
 ## 🎯 WORKING SETUP (Verified ✅)
 
 **Quick Start - Direct Docker Method:**

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -36,9 +36,23 @@ class Installer:
 
     def _check_system_requirements(self):
         """Validate system requirements."""
-        # Check macOS
-        if platform.system() != "Darwin":
-            raise SystemRequirementsError("This installer only supports macOS")
+        # Determine operating system
+        system = platform.system()
+
+        # Windows is only supported when running under WSL
+        if system == "Windows":
+            if "microsoft" not in platform.release().lower():
+                raise SystemRequirementsError(
+                    "Windows is supported only via WSL (Linux subsystem)"
+                )
+            # Treat WSL as Linux
+            system = "Linux"
+
+        if system not in {"Darwin", "Linux"}:
+            raise SystemRequirementsError(
+                f"Unsupported operating system: {system}. "
+                "Supported platforms are macOS, Linux, and Windows via WSL."
+            )
 
         # Check Python version (aligned with setup.py)
         if sys.version_info < (3, 9):


### PR DESCRIPTION
## Summary
- allow Linux & WSL in system requirements
- run CI on macOS and Linux
- test installer on both macOS and Linux
- document supported platforms in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858291731e08326a0318a0163440bf3