### PR TITLE
Automate Homebrew formula updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,47 +187,23 @@ jobs:
         asset_name: openwebui-installer-${{ steps.extract_version.outputs.VERSION }}.tar.gz
         asset_content_type: application/gzip
 
-    - name: Generate SHA256 for Homebrew
+    - name: Update Homebrew formula
+      env:
+        HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       run: |
         cd release
         ARCHIVE_NAME="openwebui-installer-${{ steps.extract_version.outputs.VERSION }}.tar.gz"
         SHA256=$(shasum -a 256 "$ARCHIVE_NAME" | cut -d' ' -f1)
 
-        echo "================================================"
-        echo "🍺 HOMEBREW FORMULA UPDATE REQUIRED"
-        echo "================================================"
-        echo ""
-        echo "Archive: $ARCHIVE_NAME"
-        echo "SHA256: $SHA256"
-        echo ""
-        echo "Update your Formula/openwebui-installer.rb file with:"
-        echo ""
-        echo "url \"https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/${{ steps.extract_version.outputs.VERSION }}.tar.gz\""
-        echo "sha256 \"$SHA256\""
-        echo ""
-        echo "================================================"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git clone https://$HOMEBREW_TAP_TOKEN@github.com/open-webui/homebrew-openwebui-installer.git ../tap
+        python ../scripts/update_formula.py "${{ steps.extract_version.outputs.VERSION }}" "$ARCHIVE_NAME" ../tap --commit
+        cd ../tap
+        git push origin HEAD:main
 
-        # Create GitHub Actions summary
-        echo "## 🍺 Homebrew Formula Update Required" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Update your \`Formula/openwebui-installer.rb\` file in the [homebrew-openwebui-installer](https://github.com/STEALTHTEMP1/homebrew-openwebui-installer) repository:" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`ruby" >> $GITHUB_STEP_SUMMARY
-        echo "url \"https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/${{ steps.extract_version.outputs.VERSION }}.tar.gz\"" >> $GITHUB_STEP_SUMMARY
-        echo "sha256 \"$SHA256\"" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Quick Update Command" >> $GITHUB_STEP_SUMMARY
-        echo "If you have the update script, run:" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "./update-formula.sh ${{ steps.extract_version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Manual Steps" >> $GITHUB_STEP_SUMMARY
-        echo "1. Update the formula file with the new URL and SHA256" >> $GITHUB_STEP_SUMMARY
-        echo "2. Test with \`brew audit --strict Formula/openwebui-installer.rb\`" >> $GITHUB_STEP_SUMMARY
-        echo "3. Commit and push the changes" >> $GITHUB_STEP_SUMMARY
-        echo "4. Test installation: \`brew install STEALTHTEMP1/openwebui-installer/openwebui-installer\`" >> $GITHUB_STEP_SUMMARY
+        echo "## 🍺 Homebrew formula updated" >> $GITHUB_STEP_SUMMARY
+        echo "URL: https://github.com/open-webui/homebrew-openwebui-installer" >> $GITHUB_STEP_SUMMARY
 
     - name: Verify Release
       run: |
@@ -241,6 +217,6 @@ jobs:
         echo ""
         echo "Next steps:"
         echo "1. ✅ Release created and archive uploaded"
-        echo "2. 🔄 Update Homebrew formula with the SHA256 hash above"
+        echo "2. ✅ Homebrew formula updated"
         echo "3. 🧪 Test the installation"
         echo "4. 📢 Announce the release!"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,7 +47,7 @@ The following secrets must be configured in GitHub repository settings:
      2. Build package
      3. Create GitHub Release
      4. Publish to PyPI
-     5. Update Homebrew formula
+     5. Update the Homebrew formula using `scripts/update_formula.py`
 
 4. **Verify Release**
    - Check GitHub release page
@@ -69,6 +69,7 @@ The following secrets must be configured in GitHub repository settings:
 1. Verify tap repository permissions
 2. Check HOMEBREW_TAP_TOKEN permissions
 3. Ensure formula template is valid
+4. Run `scripts/update_formula.py <version> <tarball> <tap-path> --commit` manually if needed
 
 ## Rolling Back a Release
 

--- a/scripts/update_formula.py
+++ b/scripts/update_formula.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Update Homebrew formula with new version and SHA256 checksum."""
+import argparse
+import hashlib
+import re
+from pathlib import Path
+import subprocess
+
+
+def compute_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def update_formula(version: str, tarball: Path, formula_path: Path) -> str:
+    checksum = compute_sha256(tarball)
+    content = formula_path.read_text()
+    content = re.sub(r'url "[^"]+"',
+                     f'url "https://github.com/open-webui/openwebui-installer/archive/refs/tags/{version}.tar.gz"',
+                     content)
+    content = re.sub(r'sha256 "[^"]+"', f'sha256 "{checksum}"', content)
+    formula_path.write_text(content)
+    return checksum
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update Homebrew formula file")
+    parser.add_argument("version", help="Release version e.g. v1.2.3")
+    parser.add_argument("tarball", help="Path to release tarball")
+    parser.add_argument("tap_path", help="Path to Homebrew tap repository")
+    parser.add_argument("--commit", action="store_true", help="Commit the change")
+    args = parser.parse_args()
+
+    tap_path = Path(args.tap_path)
+    formula = tap_path / "Formula" / "openwebui-installer.rb"
+    checksum = update_formula(args.version, Path(args.tarball), formula)
+
+    if args.commit:
+        subprocess.run(["git", "add", str(formula)], cwd=tap_path, check=True)
+        subprocess.run([
+            "git",
+            "commit",
+            "-m",
+            f"Update openwebui-installer to {args.version}",
+            "-m",
+            f"SHA256: {checksum}",
+        ], cwd=tap_path, check=True)
+
+    print(f"Updated {formula} with SHA256 {checksum}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/update_formula.py` to update the tap formula
- automate formula update in the release workflow
- document automated formula updates in `RELEASING.md`

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6858295fab5083268b7da16ca0e35883