### PR TITLE
Refine GUI status text formatting

### DIFF
--- a/openwebui_installer/gui.py
+++ b/openwebui_installer/gui.py
@@ -125,11 +125,15 @@ class MainWindow(QMainWindow):
 
             if status["installed"]:
                 self.status_label.setText(
-                    f"Open WebUI is installed\n"
-                    f"Version: {status['version']}\n"
-                    f"Port: {status['port']}\n"
-                    f"Model: {status['model']}\n"
-                    f"Status: {'Running' if status['running'] else 'Stopped'}"
+                    "\n".join(
+                        [
+                            "Open WebUI is installed",
+                            f"Version: {status['version']}",
+                            f"Port: {status['port']}",
+                            f"Model: {status['model']}",
+                            f"Status: {'Running' if status['running'] else 'Stopped'}",
+                        ]
+                    )
                 )
                 self.status_label.show()
                 self.install_button.setText("Reinstall")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -142,3 +142,37 @@ def test_uninstall_with_error(window):
                     warning_args = mock_warning.call_args[0]
                     assert "Could not uninstall" in warning_args[2]  # message is third argument
                     mock_update.assert_called_once()
+
+
+@patch("openwebui_installer.gui.Installer")
+def test_update_status_installed_sets_label(mock_installer, qapp):
+    """Verify installed status label text is joined correctly."""
+    status = {
+        "installed": True,
+        "version": "1.2.3",
+        "port": 1234,
+        "model": "llama2",
+        "running": False,
+    }
+    mock_installer.return_value.get_status.return_value = status
+
+    # Patch update_status during initialization only
+    with patch.object(MainWindow, "update_status"):
+        win = MainWindow()
+
+    expected_text = "\n".join(
+        [
+            "Open WebUI is installed",
+            f"Version: {status['version']}",
+            f"Port: {status['port']}",
+            f"Model: {status['model']}",
+            f"Status: {'Running' if status['running'] else 'Stopped'}",
+        ]
+    )
+
+    with patch.object(win.status_label, "setText") as mock_set_text:
+        win.update_status()
+        mock_set_text.assert_called_once_with(expected_text)
+
+    win.close()
+    qapp.processEvents()


### PR DESCRIPTION
## Summary
- format GUI installation status text with join
- test GUI status join formatting

## Testing
- `apt-get update`
- `apt-get install -y libegl1`
- `pip install -r requirements-dev.txt`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582c65a85c8326a0c80235429e8bb1