### PR TITLE
Enable Linux installer support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,8 +18,8 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Target Platform**
 - [ ] macOS
-- [ ] Linux (future)
-- [ ] Windows (future)
+- [ ] Linux
+- [ ] Windows (WSL)
 
 **Additional context**
 Add any other context or screenshots about the feature request here. 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Easy installer and manager for Open WebUI - User-friendly AI Interface
 
+## 🖥️ Supported Platforms
+- macOS
+- Linux
+- Windows via WSL
+
 ## 🎯 WORKING SETUP (Verified ✅)
 
 **Quick Start - Direct Docker Method:**

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -36,9 +36,16 @@ class Installer:
 
     def _check_system_requirements(self):
         """Validate system requirements."""
-        # Check macOS
-        if platform.system() != "Darwin":
-            raise SystemRequirementsError("This installer only supports macOS")
+        # Check supported operating systems
+        os_name = platform.system()
+        if os_name == "Windows":
+            raise SystemRequirementsError(
+                "Please run this installer inside WSL on Windows"
+            )
+        if os_name not in ("Darwin", "Linux"):
+            raise SystemRequirementsError(
+                "This installer supports macOS, Linux, and Windows via WSL"
+            )
 
         # Check Python version (aligned with setup.py)
         if sys.version_info < (3, 9):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -33,21 +33,22 @@ def installer(tmp_path, mocker): # Added mocker
 class TestInstallerSuite:
     """A comprehensive and corrected test suite for the Installer class."""
 
-    def test_check_system_requirements_success(self, installer, mocker):
-        """Test that system requirements check passes on macOS with Docker and Ollama running."""
-        mocker.patch('platform.system', return_value='Darwin')
+    @pytest.mark.parametrize('os_name', ['Darwin', 'Linux'])
+    def test_check_system_requirements_success(self, installer, mocker, os_name):
+        """System requirements check passes on supported platforms."""
+        mocker.patch('platform.system', return_value=os_name)
         mocker.patch('sys.version_info', (3, 9, 0))
         installer.docker_client.ping.return_value = True
         mock_requests_get = mocker.patch('requests.get')
         mock_requests_get.return_value.status_code = 200
 
-        # This should not raise any exception
+        # Should not raise any exception
         installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_os(self, installer, mocker):
-        """Test that system requirements check fails on a non-macOS system."""
-        mocker.patch('platform.system', return_value='Linux')
-        with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
+        """System requirements check fails on unsupported OS."""
+        mocker.patch('platform.system', return_value='Windows')
+        with pytest.raises(SystemRequirementsError, match="WSL"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):


### PR DESCRIPTION
## Summary
- support Linux and WSL in `_check_system_requirements`
- cover Linux in installer tests
- mention supported platforms in README
- run CI on both macOS and Linux
- update feature request template

## Testing
- `PYTHONPATH=. QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582c66d1e083269a58f5d07b81f800