### PR TITLE
Add Linux support to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,24 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install system dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libegl1
+
+    - name: Configure Qt for headless tests
+      if: runner.os == 'Linux'
+      run: echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- run test job on `ubuntu-latest` and `macos-latest`
- install `libegl1` and configure Qt for headless mode on Linux

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68582c7718608326987fb3fe687fc41a