### PR TITLE
Implement start/stop/restart CLI commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,15 +138,13 @@ jobs:
           openwebui-installer stop        # Stop the service
           openwebui-installer restart     # Restart the service
           openwebui-installer status      # Check service status
-          openwebui-installer update      # Update Open WebUI
           openwebui-installer uninstall   # Remove Open WebUI
-          openwebui-installer logs        # View service logs
           openwebui-installer --help      # Show all commands
           openwebui-installer --version   # Show version info
           ```
 
           ### 🔧 Troubleshooting
-          - **Service won't start?** Check logs with `openwebui-installer logs`
+          - **Service won't start?** Check Docker container status
           - **Port conflicts?** Use `openwebui-installer config` to change ports
           - **Docker issues?** Ensure Docker is running and accessible
           - **Permission errors?** Try running with appropriate permissions

--- a/README.md
+++ b/README.md
@@ -50,19 +50,16 @@ openwebui-installer install
 
 ```bash
 # Check status
-docker ps | grep open-webui
+openwebui-installer status
 
-# View logs
-docker logs open-webui
+# Start service
+openwebui-installer start
 
-# Stop container
-docker stop open-webui
+# Stop service
+openwebui-installer stop
 
-# Start container
-docker start open-webui
-
-# Remove container
-docker rm open-webui
+# Restart service
+openwebui-installer restart
 ```
 
 ## 📖 Documentation

--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -87,6 +87,42 @@ def uninstall():
 
 
 @cli.command()
+def start():
+    """Start Open WebUI service."""
+    try:
+        installer = Installer()
+        installer.start()
+        console.print("[green]✓[/green] Open WebUI started")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def stop():
+    """Stop Open WebUI service."""
+    try:
+        installer = Installer()
+        installer.stop()
+        console.print("[green]✓[/green] Open WebUI stopped")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def restart():
+    """Restart Open WebUI service."""
+    try:
+        installer = Installer()
+        installer.restart()
+        console.print("[green]✓[/green] Open WebUI restarted")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
 def status():
     """Check Open WebUI installation status."""
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch, Mock
 import pytest
 from click.testing import CliRunner
 
-from openwebui_installer.cli import cli, install, uninstall, status
+from openwebui_installer.cli import cli, install, uninstall, status, start, stop, restart
 from openwebui_installer.installer import InstallerError, SystemRequirementsError
 
 @pytest.fixture
@@ -234,3 +234,43 @@ class TestCLI:
             force=False,       # Default from CLI
             image='custom/image:tag' # Provided in test
         )
+
+    def test_start_command(self, runner, mock_installer):
+        """Test start command"""
+        result = runner.invoke(start)
+        assert result.exit_code == 0
+        mock_installer.start.assert_called_once()
+
+    def test_start_command_error(self, runner, mock_installer):
+        """Test start command failure"""
+        mock_installer.start.side_effect = InstallerError('fail')
+        result = runner.invoke(start)
+        assert result.exit_code == 1
+        assert 'fail' in result.output
+
+    def test_stop_command(self, runner, mock_installer):
+        """Test stop command"""
+        result = runner.invoke(stop)
+        assert result.exit_code == 0
+        mock_installer.stop.assert_called_once()
+
+    def test_stop_command_error(self, runner, mock_installer):
+        """Test stop command failure"""
+        mock_installer.stop.side_effect = InstallerError('fail')
+        result = runner.invoke(stop)
+        assert result.exit_code == 1
+        assert 'fail' in result.output
+
+    def test_restart_command(self, runner, mock_installer):
+        """Test restart command"""
+        result = runner.invoke(restart)
+        assert result.exit_code == 0
+        mock_installer.restart.assert_called_once()
+
+    def test_restart_command_error(self, runner, mock_installer):
+        """Test restart command failure"""
+        mock_installer.restart.side_effect = InstallerError('fail')
+        result = runner.invoke(restart)
+        assert result.exit_code == 1
+        assert 'fail' in result.output
+


### PR DESCRIPTION
## Summary
- add service management methods to `Installer`
- expose `start`, `stop`, `restart` commands in the CLI
- update README with new service commands
- adjust release workflow docs
- expand CLI tests for the new commands

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582c6f42608326aca810ce30aeeef6