### PR TITLE
Improve script safety

### DIFF
--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # setup.sh - Setup script for your private repository
 # This script helps you set up the automated release workflow
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- add strict error handling to test_installation.sh
- enforce strict mode in setup.sh

## Testing
- `bash -n setup.sh`
- `bash -n scripts/test_installation.sh`
- `./setup.sh --help`
- `bash scripts/test_installation.sh` *(fails: Could not find a version that satisfies the requirement openwebui-installer)*

------
https://chatgpt.com/codex/tasks/task_e_685834ae6b70832696344170288ac194