### PR TITLE
Handle optional test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then access: **http://localhost:3000**
 
 - Docker Desktop installed and running
 - Web browser
+- Optional for running tests: `docker` and `requests` Python packages (`pip install docker requests`)
 
 ## 🚀 Installation Methods
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -7,8 +7,9 @@ import shutil
 import subprocess
 from unittest.mock import MagicMock, mock_open
 
-import docker
 import pytest
+docker = pytest.importorskip("docker")
+requests = pytest.importorskip("requests")
 from openwebui_installer.installer import (Installer, InstallerError,
                                            SystemRequirementsError)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,8 +5,8 @@ Integration tests for Open WebUI Installer
 import os
 import subprocess
 import pytest
-import docker
-import requests
+docker = pytest.importorskip("docker")
+requests = pytest.importorskip("requests")
 from pathlib import Path
 from openwebui_installer.installer import Installer
 from unittest.mock import patch, Mock, MagicMock # Added MagicMock


### PR DESCRIPTION
## Summary
- detect missing docker or requests modules in tests
- document optional Python module dependencies

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_cli.py tests/test_installer.py tests/test_integration.py -p pytest_cov -p pytest_mock -p no:pytestqt -q`

------
https://chatgpt.com/codex/tasks/task_e_68583613c1f883268c603b20aecd5c0d