### PR TITLE
Align version references to __version__

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Once the workflow is set up:
 
 1. **Tag your release**:
    ```bash
-   git tag v1.0.0
-   git push origin v1.0.0
+   git tag v0.1.0
+   git push origin v0.1.0
    ```
 
 2. **Watch the workflow run**:
@@ -138,13 +138,13 @@ After each release, you'll need to update your public Homebrew tap:
 
 2. **Update the formula** with the new version and SHA256:
    ```ruby
-   url "https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/v1.0.0.tar.gz"
+   url "https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/v0.1.0.tar.gz"
    sha256 "your-sha256-hash-here"
    ```
 
 3. **Or use the update script**:
    ```bash
-   ./update-formula.sh v1.0.0
+   ./update-formula.sh v0.1.0
    ```
 
 ## 📁 What's Included
@@ -158,7 +158,7 @@ After each release, you'll need to update your public Homebrew tap:
 
 The automated workflow:
 
-- ✅ **Triggers on git tags** (v1.0.0, v1.1.0, etc.)
+- ✅ **Triggers on git tags** (v0.1.0, v0.2.0, etc.)
 - ✅ **Creates release archives** automatically
 - ✅ **Uploads to GitHub Releases** with detailed descriptions
 - ✅ **Calculates SHA256 hashes** for Homebrew
@@ -219,7 +219,7 @@ The workflow works with any project structure. It automatically includes all fil
 1. **Download the exact release archive** from GitHub
 2. **Calculate hash locally**:
    ```bash
-   curl -L -o temp.tar.gz "https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/v1.0.0.tar.gz"
+   curl -L -o temp.tar.gz "https://github.com/STEALTHTEMP1/openwebui-installer/archive/refs/tags/v0.1.0.tar.gz"
    shasum -a 256 temp.tar.gz
    ```
 3. **Use the exact hash** in your Homebrew formula
@@ -233,7 +233,7 @@ The workflow works with any project structure. It automatically includes all fil
 ## 🎯 Next Steps
 
 1. **Set up the workflow** (run `./setup.sh`)
-2. **Create your first release** (`git tag v1.0.0 && git push origin v1.0.0`)
+2. **Create your first release** (`git tag v0.1.0 && git push origin v0.1.0`)
 3. **Set up your Homebrew tap** (see main project documentation)
 4. **Test the complete flow** end-to-end
 

--- a/WORKING_SETUP.md
+++ b/WORKING_SETUP.md
@@ -103,6 +103,6 @@ The installer can be updated to use this working Docker command instead of the c
 
 ## 📝 Notes for Future Development
 
-- The current installer (v1.1.1) needs to be updated to use the official Open WebUI image
+ - The current installer (v0.1.0) needs to be updated to use the official Open WebUI image
 - Consider removing the custom development setup and using this proven Docker approach
 - Port 3000 works well but can be changed if needed (e.g., `-p 8080:8080`)

--- a/install.py
+++ b/install.py
@@ -9,12 +9,14 @@ import argparse
 import subprocess
 import os
 
+from openwebui_installer import __version__
+
 def main():
     parser = argparse.ArgumentParser(description='Open WebUI Installer')
     parser.add_argument('command', nargs='?', default='help',
                        choices=['install', 'start', 'stop', 'status', 'update', 'uninstall', 'help'],
                        help='Command to execute')
-    parser.add_argument('--version', action='version', version='1.1.1')
+    parser.add_argument('--version', action='version', version=__version__)
 
     args = parser.parse_args()
 

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from typing import Dict, Optional
 
+from . import __version__
+
 import docker
 import requests
 from rich.console import Console
@@ -112,7 +114,7 @@ docker run -d \\
 
             # Create configuration file
             config = {
-                "version": "0.1.0",
+                "version": __version__,
                 "model": model,
                 "port": port,
                 "image": current_webui_image,

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
+from openwebui_installer import __version__
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
     name="openwebui-installer",
-    version="0.1.0",
+    version=__version__,
     author="Open WebUI Team",
     author_email="team@openwebui.com",
     description="A macOS installer for Open WebUI with native Ollama integration",

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Get project version from __init__.py
+VERSION=$(grep -oP '(?<=__version__ = ")\S+(?=")' openwebui_installer/__init__.py)
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -439,7 +442,7 @@ EOF
         if [[ "$DRY_RUN" == true ]]; then
             log_info "Would create: install.py (sample)"
         else
-            cat > install.py << 'EOF'
+            cat > install.py << EOF
 #!/usr/bin/env python3
 """
 Open WebUI Installer
@@ -456,7 +459,7 @@ def main():
     parser.add_argument('command', nargs='?', default='help',
                        choices=['install', 'start', 'stop', 'status', 'update', 'uninstall', 'help'],
                        help='Command to execute')
-    parser.add_argument('--version', action='version', version='1.1.1')
+    parser.add_argument('--version', action='version', version='${VERSION}')
 
     args = parser.parse_args()
 
@@ -561,8 +564,8 @@ show_next_steps() {
     echo "   git push origin main"
     echo ""
     echo "3. 🏷️  Create your first release:"
-    echo "   git tag v1.0.0"
-    echo "   git push origin v1.0.0"
+    echo "   git tag v${VERSION}"
+    echo "   git push origin v${VERSION}"
     echo ""
     echo "4. 👀 Watch the magic happen:"
     echo "   - Go to your GitHub repository"
@@ -573,7 +576,7 @@ show_next_steps() {
     echo "5. 🍺 Update your Homebrew formula:"
     echo "   - Go to your homebrew-openwebui-installer repository"
     echo "   - Update Formula/openwebui-installer.rb with the new SHA256"
-    echo "   - Or use: ./update-formula.sh v1.0.0"
+    echo "   - Or use: ./update-formula.sh v${VERSION}"
     echo ""
     echo "6. 🧪 Test the installation:"
     echo "   brew tap STEALTHTEMP1/openwebui-installer"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from openwebui_installer.cli import cli, install, uninstall, status
 from openwebui_installer.installer import InstallerError, SystemRequirementsError
+from openwebui_installer import __version__
 
 @pytest.fixture
 def runner():
@@ -105,7 +106,7 @@ def test_status_installed_not_running(runner, mock_installer):
     """Test status command when installed but not running."""
     mock_installer.get_status.return_value = {
         "installed": True,
-        "version": "0.1.0",
+        "version": __version__,
         "port": 3000,
         "model": "llama2",
         "running": False,
@@ -119,7 +120,7 @@ def test_status_installed_and_running(runner, mock_installer):
     """Test status command when installed and running."""
     mock_installer.get_status.return_value = {
         "installed": True,
-        "version": "0.1.0",
+        "version": __version__,
         "port": 3000,
         "model": "llama2",
         "running": True,
@@ -173,7 +174,7 @@ class TestCLI:
         """Test status command"""
         # Test when Open WebUI is running
         mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
+            "installed": True, "version": __version__, "port": 3000,
             "model": "test", "running": True
         }
         result = runner.invoke(status)
@@ -183,7 +184,7 @@ class TestCLI:
 
         # Test when Open WebUI is not running
         mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
+            "installed": True, "version": __version__, "port": 3000,
             "model": "test", "running": False
         }
         result = runner.invoke(status)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 import docker
 import requests
+from openwebui_installer import __version__
 from pathlib import Path
 from openwebui_installer.installer import Installer
 from unittest.mock import patch, Mock, MagicMock # Added MagicMock
@@ -103,10 +104,10 @@ def test_status_check(installer):
     with patch('os.path.exists', return_value=True), \
          patch('builtins.open', create=True) as mock_open:
 
-        mock_open.return_value.__enter__.return_value.read.return_value = '{"version": "0.1.0", "port": 3000, "model": "llama2"}'
+        mock_open.return_value.__enter__.return_value.read.return_value = '{"version": "' + __version__ + '", "port": 3000, "model": "llama2"}'
 
         with patch.object(installer.docker_client.containers, 'get', side_effect=docker.errors.NotFound("Container not found")):
             status = installer.get_status()
             assert status["installed"] is True
-            assert status["version"] == "0.1.0"
+            assert status["version"] == __version__
             assert status["running"] is False


### PR DESCRIPTION
## Summary
- centralize version retrieval from `openwebui_installer.__version__`
- update install.py and installer config
- replace hard-coded examples in README and docs
- reference version variable in setup.sh for generated scripts
- use __version__ constant in tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685836a327188326a1f61e4ef595d9ba