### PR TITLE
Add Linux support for system requirements

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -36,9 +36,12 @@ class Installer:
 
     def _check_system_requirements(self):
         """Validate system requirements."""
-        # Check macOS
-        if platform.system() != "Darwin":
-            raise SystemRequirementsError("This installer only supports macOS")
+        # Check supported operating systems (macOS and Linux)
+        system = platform.system()
+        if system not in ("Darwin", "Linux"):
+            raise SystemRequirementsError(
+                "This installer only supports macOS and Linux"
+            )
 
         # Check Python version (aligned with setup.py)
         if sys.version_info < (3, 9):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -44,10 +44,20 @@ class TestInstallerSuite:
         # This should not raise any exception
         installer._check_system_requirements()
 
-    def test_check_system_requirements_wrong_os(self, installer, mocker):
-        """Test that system requirements check fails on a non-macOS system."""
+    def test_check_system_requirements_linux_success(self, installer, mocker):
+        """Test that system requirements check passes on Linux."""
         mocker.patch('platform.system', return_value='Linux')
-        with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
+        mocker.patch('sys.version_info', (3, 9, 0))
+        installer.docker_client.ping.return_value = True
+        mock_requests_get = mocker.patch('requests.get')
+        mock_requests_get.return_value.status_code = 200
+
+        installer._check_system_requirements()
+
+    def test_check_system_requirements_wrong_os(self, installer, mocker):
+        """Test that system requirements check fails on an unsupported operating system."""
+        mocker.patch('platform.system', return_value='Windows')
+        with pytest.raises(SystemRequirementsError, match="This installer only supports macOS and Linux"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):


### PR DESCRIPTION
## Summary
- allow installer to run on Linux in addition to macOS
- update installer tests for new OS support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685836aa0cbc8326a64a78b4677c8457