### PR TITLE
Add start/stop/restart commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ docker start open-webui
 docker rm open-webui
 ```
 
+### CLI Management
+
+The installer provides commands to control the container without using raw Docker commands:
+
+```bash
+openwebui-installer start      # Start Open WebUI
+openwebui-installer stop       # Stop the container
+openwebui-installer restart    # Restart the container
+openwebui-installer status     # Show current status
+```
+
 ## 📖 Documentation
 
 - [Working Setup Guide](WORKING_SETUP.md) - Detailed troubleshooting and setup notes

--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -107,6 +107,75 @@ def status():
         sys.exit(1)
 
 
+@cli.command()
+def start():
+    """Start Open WebUI."""
+    try:
+        if not validate_system():
+            sys.exit(1)
+
+        installer = Installer()
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Starting Open WebUI...", total=None)
+            installer.start()
+            progress.update(task, completed=True)
+
+        console.print("[green]✓[/green] Open WebUI started!")
+
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def stop():
+    """Stop Open WebUI."""
+    try:
+        installer = Installer()
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Stopping Open WebUI...", total=None)
+            installer.stop()
+            progress.update(task, completed=True)
+
+        console.print("[green]✓[/green] Open WebUI stopped!")
+
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def restart():
+    """Restart Open WebUI."""
+    try:
+        if not validate_system():
+            sys.exit(1)
+
+        installer = Installer()
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Restarting Open WebUI...", total=None)
+            installer.restart()
+            progress.update(task, completed=True)
+
+        console.print("[green]✓[/green] Open WebUI restarted!")
+
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
 def main():
     """Main entry point for the CLI."""
     cli()

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -214,3 +214,55 @@ docker run -d \\
             pass
 
         return status
+
+    def start(self):
+        """Start the Open WebUI container."""
+        try:
+            self._check_system_requirements()
+
+            config_path = os.path.join(self.config_dir, "config.json")
+            if not os.path.exists(config_path):
+                raise InstallerError("Open WebUI is not installed")
+
+            with open(config_path) as f:
+                config = json.load(f)
+
+            image = config.get("image", self.webui_image)
+            port = config.get("port", 3000)
+
+            try:
+                container = self.docker_client.containers.get("open-webui")
+                container.start()
+            except docker.errors.NotFound:
+                container = self.docker_client.containers.run(
+                    image,
+                    name="open-webui",
+                    ports={"8080/tcp": port},
+                    volumes={"open-webui": {"bind": "/app/backend/data", "mode": "rw"}},
+                    environment={"OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"},
+                    extra_hosts={"host.docker.internal": "host-gateway"},
+                    detach=True,
+                    restart_policy={"Name": "unless-stopped"},
+                )
+            return container
+        except Exception as e:
+            raise InstallerError(f"Failed to start Open WebUI container: {str(e)}")
+
+    def stop(self):
+        """Stop the Open WebUI container if it is running."""
+        try:
+            try:
+                container = self.docker_client.containers.get("open-webui")
+                container.stop()
+            except docker.errors.NotFound:
+                return
+        except Exception as e:
+            raise InstallerError(f"Failed to stop Open WebUI container: {str(e)}")
+
+    def restart(self):
+        """Restart the Open WebUI container."""
+        try:
+            self.stop()
+            self.start()
+        except Exception as e:
+            raise InstallerError(f"Failed to restart Open WebUI container: {str(e)}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,3 +234,36 @@ class TestCLI:
             force=False,       # Default from CLI
             image='custom/image:tag' # Provided in test
         )
+
+    def test_start_command(self, runner, mock_installer):
+        """Test start command"""
+        result = runner.invoke(cli, ["start"])
+        assert result.exit_code == 0
+        mock_installer.start.assert_called_once()
+
+        mock_installer.start.side_effect = InstallerError("Start failed")
+        result = runner.invoke(cli, ["start"])
+        assert result.exit_code == 1
+        assert "Start failed" in result.output
+
+    def test_stop_command(self, runner, mock_installer):
+        """Test stop command"""
+        result = runner.invoke(cli, ["stop"])
+        assert result.exit_code == 0
+        mock_installer.stop.assert_called_once()
+
+        mock_installer.stop.side_effect = InstallerError("Stop failed")
+        result = runner.invoke(cli, ["stop"])
+        assert result.exit_code == 1
+        assert "Stop failed" in result.output
+
+    def test_restart_command(self, runner, mock_installer):
+        """Test restart command"""
+        result = runner.invoke(cli, ["restart"])
+        assert result.exit_code == 0
+        mock_installer.restart.assert_called_once()
+
+        mock_installer.restart.side_effect = InstallerError("Restart failed")
+        result = runner.invoke(cli, ["restart"])
+        assert result.exit_code == 1
+        assert "Restart failed" in result.output

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -253,6 +253,71 @@ class TestInstallerSuite:
         mock_container.stop.assert_called_once()
         mock_container.remove.assert_called_once()
 
+    def test_start_existing_container(self, installer, mocker):
+        """Start should start existing container"""
+        mocker.patch.object(installer, '_check_system_requirements')
+        config = '{"port": 3000, "image": "img"}'
+        mocker.patch('builtins.open', mock_open(read_data=config))
+        mocker.patch('os.path.exists', return_value=True)
+        mock_container = MagicMock()
+        installer.docker_client.containers.get.return_value = mock_container
+
+        installer.start()
+
+        mock_container.start.assert_called_once()
+        installer.docker_client.containers.run.assert_not_called()
+
+    def test_start_creates_container_when_missing(self, installer, mocker):
+        """Start should create container if not present"""
+        mocker.patch.object(installer, '_check_system_requirements')
+        config = '{"port": 1234, "image": "custom"}'
+        mocker.patch('builtins.open', mock_open(read_data=config))
+        mocker.patch('os.path.exists', return_value=True)
+        installer.docker_client.containers.get.side_effect = docker.errors.NotFound("missing")
+
+        installer.start()
+
+        installer.docker_client.containers.run.assert_called_once_with(
+            'custom',
+            name='open-webui',
+            ports={'8080/tcp': 1234},
+            volumes={'open-webui': {'bind': '/app/backend/data', 'mode': 'rw'}},
+            environment={'OLLAMA_API_BASE_URL': 'http://host.docker.internal:11434/api'},
+            extra_hosts={'host.docker.internal': 'host-gateway'},
+            detach=True,
+            restart_policy={'Name': 'unless-stopped'},
+        )
+
+    def test_start_without_installation(self, installer, mocker):
+        """Start should fail when not installed"""
+        mocker.patch.object(installer, '_check_system_requirements')
+        mocker.patch('os.path.exists', return_value=False)
+        with pytest.raises(InstallerError, match="Open WebUI is not installed"):
+            installer.start()
+
+    def test_stop_success(self, installer, mocker):
+        """Stop container when running"""
+        mock_container = MagicMock()
+        installer.docker_client.containers.get.return_value = mock_container
+
+        installer.stop()
+
+        mock_container.stop.assert_called_once()
+
+    def test_stop_not_running(self, installer, mocker):
+        """Stop should succeed if container not found"""
+        installer.docker_client.containers.get.side_effect = docker.errors.NotFound("missing")
+        # Should not raise
+        installer.stop()
+
+    def test_restart_calls_start_and_stop(self, installer, mocker):
+        """Restart should invoke stop and start"""
+        mocker.patch.object(installer, 'start')
+        mocker.patch.object(installer, 'stop')
+        installer.restart()
+        installer.stop.assert_called_once()
+        installer.start.assert_called_once()
+
     # def test_is_open_webui_running(self, installer, mocker):
     #     """Test checking if open webui is running."""
     #     # installer.docker_client is already a MagicMock


### PR DESCRIPTION
## Summary
- implement `start`, `stop` and `restart` in installer
- expose container control commands via CLI
- test the new methods and CLI commands
- document new CLI usage in README

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583b5eb5f88326b66e10265edccc88