### PR TITLE
Add env var support for installer

### DIFF
--- a/docker-compose.working.yml
+++ b/docker-compose.working.yml
@@ -6,8 +6,8 @@ services:
     container_name: open-webui
     ports:
       - "3000:8080"
+    env_file: .env
     environment:
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
       - WEBUI_SECRET_KEY=
     volumes:
       - open-webui:/app/backend/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ docker>=6.0.0
 requests>=2.25.0
 rich>=10.0.0
 PyQt6>=6.4.0
-psutil>=5.8.0 
+psutil>=5.8.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- load `.env` automatically and default to environment variables when starting docker container
- configure docker-compose to read env vars from `.env`
- include `python-dotenv` requirement
- adjust tests to patch environment variables accordingly

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583b55b7d88326bb08089c9cbfb977