### PR TITLE
Add Swift package skeleton for macOS wrapper

### DIFF
--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenWebUIApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "OpenWebUIApp", targets: ["OpenWebUIApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "OpenWebUIApp",
+            path: "Sources"
+        )
+    ]
+)

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,11 @@
+# Open WebUI macOS App
+
+This directory contains a minimal Swift package used as a starting point for the macOS wrapper around Open WebUI.
+
+The Swift code calls the existing Python based installer so we can reuse the container management logic without rewriting it in Swift.
+
+```bash
+swift run
+```
+
+Running the package will execute `openwebui-installer install` using the same logic as our CLI.

--- a/macos/Sources/OpenWebUIApp/main.swift
+++ b/macos/Sources/OpenWebUIApp/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Simple container manager calling the existing Python installer.
+struct ContainerManager {
+    /// Run the Python-based installer using the `openwebui-installer` CLI.
+    static func install() throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["openwebui-installer", "install"]
+        try proc.run()
+        proc.waitUntilExit()
+    }
+}
+
+print("Starting Open WebUI installer...")
+try? ContainerManager.install()

--- a/macos/run.sh
+++ b/macos/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Simple helper to run the macOS Swift package
+# Works on macOS and Linux as long as Swift is installed
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit 1
+swift run


### PR DESCRIPTION
## Summary
- initialize a new Swift package under `macos/` for the macOS wrapper
- create minimal `ContainerManager` that reuses the Python CLI
- include simple run helper script

## Testing
- `swift build` in `macos`
- `swift run` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68584179f0c88326a2f6ac0bfb4f4c88