### PR TITLE
Update installer checks and GUI status formatting

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,40 @@
+# Remaining Improvement Tasks
+
+This file tracks pending refactor and enhancement tasks for the OpenWebUI Installer.
+
+## High Priority
+
+1. **Refactor `Installer.install` logic** (`openwebui_installer/installer.py`)
+   - Split the method into helpers (`_pull_image`, `_pull_model`, `_create_launch_script`, `_start_container`).
+   - Implement rollback if container start fails (remove pulled images, delete created configs).
+2. **Add Docker client cleanup**
+   - Provide a `close()` method or context manager on `Installer` to release `docker.from_env()` resources.
+   - Ensure CLI and GUI close the client when done.
+3. **Improve error handling**
+   - Replace broad `except Exception` blocks in CLI and GUI with specific `InstallerError` and `SystemRequirementsError` handling.
+   - Surface user‑friendly messages while logging stack traces for debugging.
+4. **Extend CLI commands** (`openwebui_installer/cli.py`)
+   - Implement `start`, `stop`, and `update` commands reusing new `Installer` methods.
+   - Update help text and README examples accordingly.
+
+## Medium Priority
+
+5. **Dedicated container lifecycle methods** (`installer.py`)
+   - Add `_start_container`, `_stop_container`, and `_remove_volume` helpers used by both `install()` and `uninstall()`.
+   - Verify volume existence before removal to avoid errors.
+6. **GUI responsiveness improvements** (`openwebui_installer/gui.py`)
+   - Add timeouts to long‑running operations and emit progress updates regularly.
+   - Consider moving heavy subprocess calls to worker processes if threading is insufficient.
+7. **Structured logging**
+   - Introduce a logging module used across CLI, GUI, and installer to capture debug information.
+   - Replace `print` and `QMessageBox` error display with logging plus user messages.
+
+## Low Priority
+
+8. **Type hints and code style**
+   - Add missing type annotations throughout the project and run static analysis (`mypy`).
+9. **Integration and cross‑platform tests**
+   - Create tests covering container lifecycle on Linux and macOS environments using GitHub Actions.
+10. **Parameterize Docker image/tag**
+    - Allow overriding the OpenWebUI image via config or environment variable for easier updates.
+

--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -19,8 +19,7 @@ def validate_system() -> bool:
     """Validate system requirements."""
     try:
         installer = Installer()
-        installer._check_system_requirements()
-        return True
+        return installer.validate_system()
     except Exception as e:
         console.print(f"[red]System validation failed:[/red] {str(e)}")
         return False

--- a/openwebui_installer/gui.py
+++ b/openwebui_installer/gui.py
@@ -124,13 +124,14 @@ class MainWindow(QMainWindow):
             status = installer.get_status()
 
             if status["installed"]:
-                self.status_label.setText(
-                    f"Open WebUI is installed\n"
-                    f"Version: {status['version']}\n"
-                    f"Port: {status['port']}\n"
-                    f"Model: {status['model']}\n"
-                    f"Status: {'Running' if status['running'] else 'Stopped'}"
-                )
+                status_text = "\n".join([
+                    "Open WebUI is installed",
+                    f"Version: {status['version']}",
+                    f"Port: {status['port']}",
+                    f"Model: {status['model']}",
+                    f"Status: {'Running' if status['running'] else 'Stopped'}",
+                ])
+                self.status_label.setText(status_text)
                 self.status_label.show()
                 self.install_button.setText("Reinstall")
                 self.uninstall_button.setEnabled(True)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -47,7 +47,7 @@ class TestInstallerSuite:
     def test_check_system_requirements_wrong_os(self, installer, mocker):
         """Test that system requirements check fails on a non-macOS system."""
         mocker.patch('platform.system', return_value='Linux')
-        with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
+        with pytest.raises(SystemRequirementsError, match="This installer only supports"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):


### PR DESCRIPTION
## Summary
- allow overriding config dir
- make OS/Ollama checks configurable via environment variables
- expose `validate_system` on installer and use in CLI
- fix GUI status label formatting
- update tests
- add task list for remaining improvements

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858ef6308f0832694bb16677c2bf1cb