### PR TITLE
Add container management CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ docker start open-webui
 docker rm open-webui
 ```
 
+### Using the Installer CLI
+
+```bash
+# Start the container
+openwebui-installer start
+
+# Stop the container
+openwebui-installer stop
+
+# Update to the latest image
+openwebui-installer update
+```
+
 ## 📖 Documentation
 
 - [Working Setup Guide](WORKING_SETUP.md) - Detailed troubleshooting and setup notes

--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -107,6 +107,45 @@ def status():
         sys.exit(1)
 
 
+@cli.command()
+@click.option('--port', '-p', type=int, help='Port to run Open WebUI on')
+def start(port: Optional[int]):
+    """Start the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.start_container(port=port)
+        console.print("[green]✓[/green] Open WebUI started")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.option('--remove', '-r', is_flag=True, help='Remove container after stopping')
+def stop(remove: bool):
+    """Stop the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.stop_container(remove=remove)
+        console.print("[green]✓[/green] Open WebUI stopped")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.option('--image', help='Docker image to use for update')
+def update(image: Optional[str]):
+    """Update the Open WebUI container image."""
+    try:
+        installer = Installer()
+        installer.update(image=image)
+        console.print("[green]✓[/green] Open WebUI updated")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
 def main():
     """Main entry point for the CLI."""
     cli()


### PR DESCRIPTION
## Summary
- add start, stop, and update commands in the CLI
- implement corresponding methods in `Installer`
- extend CLI unit tests for new commands
- document CLI container management usage in README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-cov pytest-mock`
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fa73d3e8832693214bb7af75a394