### PR TITLE
Add context manager support for Installer

### DIFF
--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -18,8 +18,8 @@ console = Console()
 def validate_system() -> bool:
     """Validate system requirements."""
     try:
-        installer = Installer()
-        installer._check_system_requirements()
+        with Installer() as installer:
+            installer._check_system_requirements()
         return True
     except Exception as e:
         console.print(f"[red]System validation failed:[/red] {str(e)}")
@@ -44,15 +44,15 @@ def install(model: str, port: int, force: bool, image: Optional[str]):
         if not validate_system():
             sys.exit(1)
 
-        installer = Installer()
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console,
-        ) as progress:
-            task = progress.add_task("Installing Open WebUI...", total=None)
-            installer.install(model=model, port=port, force=force, image=image)
-            progress.update(task, completed=True)
+        with Installer() as installer:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,
+            ) as progress:
+                task = progress.add_task("Installing Open WebUI...", total=None)
+                installer.install(model=model, port=port, force=force, image=image)
+                progress.update(task, completed=True)
 
         console.print("[green]✓[/green] Installation complete!")
         console.print(f"\nOpen WebUI is now available at: http://localhost:{port}")
@@ -69,15 +69,15 @@ def uninstall():
         console.print("Uninstallation aborted.")
         return
     try:
-        installer = Installer()
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console,
-        ) as progress:
-            task = progress.add_task("Uninstalling Open WebUI...", total=None)
-            installer.uninstall()
-            progress.update(task, completed=True)
+        with Installer() as installer:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,
+            ) as progress:
+                task = progress.add_task("Uninstalling Open WebUI...", total=None)
+                installer.uninstall()
+                progress.update(task, completed=True)
 
         console.print("[green]✓[/green] Uninstallation complete!")
 
@@ -90,8 +90,8 @@ def uninstall():
 def status():
     """Check Open WebUI installation status."""
     try:
-        installer = Installer()
-        status = installer.get_status()
+        with Installer() as installer:
+            status = installer.get_status()
 
         if status['installed']:
             console.print("[green]✓[/green] Open WebUI is installed")

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -34,6 +34,26 @@ class Installer:
         self.webui_image = "ghcr.io/open-webui/open-webui:main"  # Default image
         self.config_dir = os.path.expanduser("~/.openwebui")
 
+    def close(self):
+        """Close any resources held by the installer."""
+        if hasattr(self.docker_client, "close"):
+            try:
+                self.docker_client.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Context manager support
+    # ------------------------------------------------------------------
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        # Propagate exceptions
+        return False
+
     def _check_system_requirements(self):
         """Validate system requirements."""
         # Check macOS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,11 @@ def runner():
 
 @pytest.fixture
 def mock_installer():
-    """Mock installer instance."""
-    with patch("openwebui_installer.cli.Installer") as mock:
+    """Mock installer instance as context manager."""
+    with patch("openwebui_installer.cli.Installer") as mock_cls:
         installer = Mock()
-        mock.return_value = installer
+        mock_cls.return_value.__enter__.return_value = installer
+        mock_cls.return_value.__exit__.return_value = False
         yield installer
 
 def test_version(runner):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -338,3 +338,20 @@ class TestInstallerSuite:
     #     # with pytest.raises(InstallerError):
     #         # installer.install_ollama() # Method doesn't exist
     #     pass
+
+    def test_close_calls_docker_client_close(self, mocker):
+        """Installer.close should close the docker client if available."""
+        mock_client = MagicMock()
+        mocker.patch('docker.from_env', return_value=mock_client)
+        inst = Installer()
+        inst.close()
+        mock_client.close.assert_called_once()
+
+    def test_context_manager_invokes_close(self, mocker):
+        """Using Installer as a context manager should close the docker client."""
+        mock_client = MagicMock()
+        mocker.patch('docker.from_env', return_value=mock_client)
+        with Installer() as _:
+            pass
+        mock_client.close.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add `close`, `__enter__`, and `__exit__` to `Installer`
- use context manager pattern in CLI commands
- test that the Installer's docker client closes properly
- update CLI tests to mock context manager

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fa6f3d0c83268ca13feddad06695