### PR TITLE
Add bandit scan to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,23 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 black isort
+        pip install bandit
         
     - name: Check formatting
       run: |
         black --check .
         isort --check-only --diff .
-        
+
     - name: Lint with flake8
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics 
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Security scan with Bandit
+      run: bandit -r openwebui_installer -ll
+


### PR DESCRIPTION
## Summary
- include Bandit in lint dependencies
- run Bandit security scan in CI

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685909e24e508326943041305481fd20