### PR TITLE
Add container validation and scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,31 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics 
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build development container
+      run: docker build -t openwebui-installer-dev -f Dockerfile.dev .
+
+    - name: Validate container image
+      run: docker run --rm openwebui-installer-dev python --version
+
+    - name: Scan image with Trivy
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: openwebui-installer-dev
+        format: sarif
+        output: trivy-results.sarif
+
+    - name: Upload Trivy scan results
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: trivy-results.sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,43 @@ on:
       - 'v*'
 
 jobs:
+  validate_container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      packages: write
+    steps:
+    - name: Pull Open WebUI image
+      run: docker pull ghcr.io/open-webui/open-webui:main
+
+    - name: Inspect image
+      run: docker image inspect ghcr.io/open-webui/open-webui:main
+
+    - name: Scan image with Trivy
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/open-webui/open-webui:main
+        format: sarif
+        output: trivy-image.sarif
+
+    - name: Upload Trivy scan results
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: trivy-image.sarif
+
+    - name: Save image artifact
+      run: docker save ghcr.io/open-webui/open-webui:main | gzip > openwebui-image.tar.gz
+
+    - name: Upload container image
+      uses: actions/upload-artifact@v4
+      with:
+        name: openwebui-image
+        path: openwebui-image.tar.gz
+
   release:
+    needs: validate_container
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- ensure container build and validation in CI
- validate Open WebUI image in release workflow
- run Trivy image scans and publish artifacts

## Testing
- `pytest -q`
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `black --check .`
- `isort --check-only --diff .`


------
https://chatgpt.com/codex/tasks/task_e_68590e64d948832698e677889308f623