### PR TITLE
Update docs for Universal Container App Store pivot

### DIFF
--- a/OpenWebUI-Desktop/README.md
+++ b/OpenWebUI-Desktop/README.md
@@ -2,6 +2,8 @@
 
 **Level 3 Complete Abstraction - Native macOS App for Open WebUI**
 
+> **Note**: This desktop wrapper is now maintained under the **Universal Container App Store** umbrella and may be distributed through the store alongside other containerized apps.
+
 A native macOS application that provides seamless desktop integration for Open WebUI with **zero Docker knowledge required**. Download, drag to Applications, double-click, and start chatting with AI in under 30 seconds.
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Open WebUI Installer
+# Universal Container App Store
 
-Easy installer and manager for Open WebUI - User-friendly AI Interface
+Formerly **Open WebUI Installer**, this project is evolving into a **Universal Container App Store**. The goal is to provide a streamlined way to install and manage containerized applications—including Open WebUI—through a single interface.
+
 
 ## 🎯 WORKING SETUP (Verified ✅)
 
@@ -87,6 +88,8 @@ docker rm open-webui
 # Private Repository Setup for Open WebUI Installer
 
 This directory contains everything you need to set up automated releases for your private Open WebUI Installer repository.
+
+> **Note**: The overall project is transitioning into the **Universal Container App Store**, but these release scripts continue to work for Open WebUI-specific deployments.
 
 ## 🚀 Quick Setup
 

--- a/homebrew-tap-template/README.md
+++ b/homebrew-tap-template/README.md
@@ -2,6 +2,8 @@
 
 This is the official Homebrew tap for Open WebUI Installer - an easy-to-use installer and manager for Open WebUI, a user-friendly AI interface that supports Ollama, OpenAI API, and more.
 
+> **Note**: The tap will become part of the **Universal Container App Store** project, which aims to distribute multiple containerized apps through a single interface.
+
 ## Installation
 
 First, tap this repository:

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -2,6 +2,8 @@
 
 This is the official Homebrew tap for Open WebUI tools and utilities.
 
+> **Note**: As part of the **Universal Container App Store** initiative, this tap will eventually distribute additional containerized applications beyond Open WebUI.
+
 ## Available Formulae
 
 - `openwebui-installer`: Official installer for Open WebUI with native Ollama integration for macOS

--- a/prd.md
+++ b/prd.md
@@ -1,4 +1,6 @@
-Here’s a polished Product Requirements Document (PRD) outlining the proposed macOS installer—an all-in-one GUI workflow that installs dependencies, configures Open WebUI + Ollama setup, and creates a one-click launcher. It aligns with best-practices and follows a structured PRD template  ￼.
+Here’s a polished Product Requirements Document (PRD) outlining the proposed macOS installer—an all-in-one GUI workflow that installs dependencies, configures Open WebUI + Ollama setup, and creates a one-click launcher. It aligns with best practices and follows a structured PRD template.
+
+> **Project Update**: The repository is transitioning into a **Universal Container App Store**. This document describes the original Open WebUI Installer concept and is kept for historical reference.
 
 ⸻
 

--- a/private-repo-setup/README.md
+++ b/private-repo-setup/README.md
@@ -2,6 +2,8 @@
 
 This directory contains everything you need to set up automated releases for your private Open WebUI Installer repository.
 
+> **Note**: The installer is now part of the broader **Universal Container App Store** project, but these instructions remain valid for Open WebUI deployments.
+
 ## 🚀 Quick Setup
 
 ### Option 1: Automated Setup (Recommended)


### PR DESCRIPTION
## Summary
- rebrand README to Universal Container App Store
- add pivot notice about the container app store vision to all READMEs
- keep PRD for historical reference with note about new direction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590e86729c8326ad0f4e704dfbadc6