### PR TITLE
Mark GUI tests for conditional execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ warn_unreachable = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q --cov=openwebui_installer --cov-report=term-missing --ignore=tests/test_gui.py"
+addopts = "-ra -q -m 'not gui' --cov=openwebui_installer --cov-report=term-missing"
 testpaths = ["tests"]
 markers = [
     "gui: marks tests as GUI tests (skipped in containers)",

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,12 +1,22 @@
-"""
-Tests for the GUI module
-"""
+"""Tests for the GUI module."""
 import sys
 from unittest.mock import patch, MagicMock
+
 import pytest
-from PyQt6.QtWidgets import QApplication, QMessageBox
+
+# Attempt to import PyQt6; if unavailable or missing dependencies,
+# skip the entire test module gracefully.
+try:
+    from PyQt6.QtWidgets import QApplication, QMessageBox
+except Exception as exc:  # pragma: no cover - import failure handling
+    pytest.skip(f"PyQt6 not available: {exc}", allow_module_level=True)
+
 from openwebui_installer.gui import MainWindow
 from openwebui_installer import __version__
+
+# Mark all tests in this module as GUI related so they can be skipped
+# in headless environments unless explicitly requested.
+pytestmark = pytest.mark.gui
 
 @pytest.fixture
 def window(qapp):


### PR DESCRIPTION
## Summary
- mark PyQt6 GUI tests with `pytest.mark.gui`
- skip GUI tests when PyQt6 isn't available
- update pytest config to skip GUI tests by default

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685911fc9ed48326828460e6e7216c0f