### PR TITLE
Add security scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,22 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: true
 
+    - name: Install security scanners
+      run: |
+        python -m pip install --upgrade bandit safety pip-audit
+
+    - name: Run Bandit
+      run: |
+        bandit -r openwebui_installer -f json -o bandit-report.json
+
+    - name: Run Safety
+      run: |
+        safety check --full-report --json > safety-report.json
+
+    - name: Run pip-audit
+      run: |
+        pip-audit -r requirements.txt -f json -o pip-audit-report.json
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/QA_REVIEW_SUMMARY.md
+++ b/QA_REVIEW_SUMMARY.md
@@ -206,7 +206,7 @@ docker-compose -f docker-compose.dev.yml exec dev-environment python -m pytest
 - ✅ GitHub Actions workflows configured
 - ✅ Multi-Python version testing (3.9, 3.10, 3.11)
 - ✅ Coverage reporting with Codecov
-- ⚠️ Security scanning not yet integrated
+- ✅ Security scanning with Bandit, Safety and pip-audit
 
 ## 📋 Recommendations
 


### PR DESCRIPTION
## Summary
- run bandit, safety and pip-audit in CI
- document the security scanning job in QA_REVIEW_SUMMARY

## Testing
- `pytest -q`
- `bandit -r openwebui_installer -f json -o bandit-report.json`
- `safety check --json > safety-report.json`
- `pip-audit -r requirements.txt -f json -o pip-audit-report.json` *(failed: environment blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68591335e2b883269918a21e6df77c4f