### PR TITLE
Add Terraform modules and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,52 +12,60 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-        
-    - name: Run tests
-      run: |
-        pytest tests/ --cov=openwebui_installer --cov-report=xml
-        
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: true
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: |
+          pytest tests/ --cov=openwebui_installer --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-        
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 black isort
-        
-    - name: Check formatting
-      run: |
-        black --check .
-        isort --check-only --diff .
-        
-    - name: Lint with flake8
-      run: |
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics 
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 black isort
+      - name: Check formatting
+        run: |
+          black --check .
+          isort --check-only --diff .
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+        working-directory: terraform
+      - name: Terraform Init
+        run: terraform init -backend=false
+        working-directory: terraform
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: terraform
+

--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ node_modules/
 *-image.tar*
 podman-*
 docker-*
+.terraform/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "openwebui-terraform-state"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "openwebui-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+}
+
+# VPC
+resource "aws_vpc" "this" {
+  cidr_block = var.vpc_cidr
+}
+
+resource "aws_subnet" "public" {
+  count             = length(var.public_subnets)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = element(var.public_subnets, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Security group allowing access to Open WebUI port
+resource "aws_security_group" "openwebui" {
+  name        = "openwebui-sg"
+  description = "Allow HTTP access to Open WebUI"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ECS cluster
+resource "aws_ecs_cluster" "this" {
+  name = var.cluster_name
+}
+
+module "openwebui" {
+  source            = "./modules/openwebui"
+  aws_region        = var.aws_region
+  cluster_arn       = aws_ecs_cluster.this.arn
+  subnets           = aws_subnet.public[*].id
+  security_group_id = aws_security_group.openwebui.id
+  container_image   = var.container_image
+  container_port    = var.container_port
+  desired_count     = var.desired_count
+}
+
+data "aws_availability_zones" "available" {}
+
+output "service_name" {
+  value = module.openwebui.service_name
+}

--- a/terraform/modules/openwebui/main.tf
+++ b/terraform/modules/openwebui/main.tf
@@ -1,0 +1,96 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = 7
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = var.name
+      image = var.container_image
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      essential   = true
+      environment = [for k, v in var.environment : { name = k, value = v }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = var.name
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.execution_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_policy" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "execution_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-task"
+  assume_role_policy = data.aws_iam_policy_document.task_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_policy" {
+  role       = aws_iam_role.task.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+data "aws_iam_policy_document" "task_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnets
+    security_groups  = [var.security_group_id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.execution_policy]
+}
+
+

--- a/terraform/modules/openwebui/outputs.tf
+++ b/terraform/modules/openwebui/outputs.tf
@@ -1,0 +1,3 @@
+output "service_name" {
+  value = aws_ecs_service.this.name
+}

--- a/terraform/modules/openwebui/variables.tf
+++ b/terraform/modules/openwebui/variables.tf
@@ -1,0 +1,66 @@
+variable "name" {
+  description = "Service name"
+  type        = string
+  default     = "openwebui"
+}
+
+variable "cluster_arn" {
+  description = "ECS cluster ARN"
+  type        = string
+}
+
+variable "subnets" {
+  description = "Subnets for the service"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group for the service"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 3000
+}
+
+variable "desired_count" {
+  description = "Desired number of tasks"
+  type        = number
+  default     = 1
+}
+
+variable "cpu" {
+  description = "Task CPU units"
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Task memory in MiB"
+  type        = number
+  default     = 512
+}
+
+variable "assign_public_ip" {
+  description = "Assign public IP"
+  type        = bool
+  default     = true
+}
+
+variable "environment" {
+  description = "Environment variables for container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+aws_region      = "us-east-1"
+cluster_name     = "openwebui-cluster"
+vpc_cidr         = "10.0.0.0/16"
+public_subnets   = ["10.0.1.0/24", "10.0.2.0/24"]
+container_image  = "ghcr.io/open-webui/open-webui:main"
+container_port   = 3000
+desired_count    = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+  default     = "openwebui-cluster"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Public subnet CIDR blocks"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "container_image" {
+  description = "Docker image for Open WebUI"
+  type        = string
+  default     = "ghcr.io/open-webui/open-webui:main"
+}
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 3000
+}
+
+variable "desired_count" {
+  description = "Number of desired ECS tasks"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## Summary
- add Terraform modules to deploy Open WebUI to ECS
- sample variable and backend configuration
- ignore `.terraform` state dir
- validate Terraform formatting and configuration in CI workflow

## Testing
- `pytest -q`
- `terraform fmt -recursive -check`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6859133adb2c832699c2fcfa70b4aa6b