### PR TITLE
Add monitoring stack

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -159,6 +159,17 @@ black --check .
 # Rebuild automatically
 ```
 
+### 5. Production Monitoring
+
+Use the production monitoring stack to observe running containers.
+
+```bash
+# Start Prometheus and Grafana
+docker-compose -f docker-compose.monitoring.yml up -d
+```
+Grafana will be available at http://localhost:3001 (admin/admin). Prometheus is
+accessible at http://localhost:9090.
+
 ## Service URLs
 
 When the development environment is running:
@@ -168,6 +179,7 @@ When the development environment is running:
 - **AI Jupyter**: http://localhost:8889 (with `--profile ai`)
 - **Documentation**: http://localhost:8080 (with `--profile docs`)
 - **Monitoring**: http://localhost:3000 (with `--profile monitoring`)
+- **Prod Grafana**: http://localhost:3001 (from `docker-compose.monitoring.yml`)
 - **Database**: localhost:5432
 - **Redis**: localhost:6379
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,62 @@
+version: '3.8'
+
+services:
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "3000:8080"
+    environment:
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    volumes:
+      - open-webui:/app/backend/data
+    restart: always
+    labels:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    ports:
+      - "8081:8080"
+    restart: always
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+    ports:
+      - "3001:3000"
+    restart: always
+
+volumes:
+  open-webui:
+  grafana-data:

--- a/monitoring/grafana/provisioning/datasources/all.yml
+++ b/monitoring/grafana/provisioning/datasources/all.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,13 @@
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+  - job_name: 'open-webui'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['open-webui:8080']
+

--- a/terraform/monitoring/README.md
+++ b/terraform/monitoring/README.md
@@ -1,0 +1,15 @@
+# Monitoring Module
+
+This Terraform module deploys Prometheus and Grafana using the Docker provider.
+It mirrors the configuration used in `docker-compose.monitoring.yml`.
+
+## Usage
+
+```hcl
+module "monitoring" {
+  source = "./DevOps/terraform/monitoring"
+}
+```
+
+Run `terraform init && terraform apply` to start the monitoring stack.
+Grafana will be available at `http://localhost:3001` and Prometheus at `http://localhost:9090`.

--- a/terraform/monitoring/grafana/provisioning/datasources/all.yml
+++ b/terraform/monitoring/grafana/provisioning/datasources/all.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "docker" {}
+
+resource "docker_volume" "grafana_data" {
+  name = "grafana-data"
+}
+
+resource "docker_container" "prometheus" {
+  name  = "prometheus"
+  image = "prom/prometheus:latest"
+
+  ports {
+    internal = 9090
+    external = 9090
+  }
+
+  volumes {
+    host_path      = "${path.module}/prometheus.yml"
+    container_path = "/etc/prometheus/prometheus.yml"
+  }
+}
+
+resource "docker_container" "grafana" {
+  name  = "grafana"
+  image = "grafana/grafana:latest"
+
+  env = ["GF_SECURITY_ADMIN_PASSWORD=admin"]
+
+  ports {
+    internal = 3000
+    external = 3001
+  }
+
+  volumes {
+    volume_name    = docker_volume.grafana_data.name
+    container_path = "/var/lib/grafana"
+  }
+
+  volumes {
+    host_path      = "${path.module}/grafana/provisioning"
+    container_path = "/etc/grafana/provisioning"
+  }
+}

--- a/terraform/monitoring/prometheus.yml
+++ b/terraform/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']


### PR DESCRIPTION
## Summary
- add `docker-compose.monitoring.yml` with Prometheus & Grafana
- expose container metrics via cadvisor and scrape labels
- document production monitoring in `DEV_ENVIRONMENT.md`
- include optional Terraform module for monitoring

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68591557e95c8326b5c257919db0b8f0