### PR TITLE
Add flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 127
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,openwebui_installer.egg-info
+max-complexity = 10
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics 
+        flake8 . --count --exit-zero --statistics

--- a/openwebui_installer/gui.py
+++ b/openwebui_installer/gui.py
@@ -199,7 +199,10 @@ class MainWindow(QMainWindow):
         QMessageBox.information(
             self,
             "Installation Complete",
-            f"Open WebUI has been installed and is available at:\nhttp://localhost:{self.port_spin.value()}"
+            (
+                "Open WebUI has been installed and is available at:\n"
+                f"http://localhost:{self.port_spin.value()}"
+            ),
         )
         self.update_status()
 

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -64,7 +64,13 @@ class Installer:
         """Ensure configuration directory exists."""
         os.makedirs(self.config_dir, exist_ok=True)
 
-    def install(self, model: str = "llama2", port: int = 3000, force: bool = False, image: Optional[str] = None):
+    def install(
+        self,
+        model: str = "llama2",
+        port: int = 3000,
+        force: bool = False,
+        image: Optional[str] = None,
+    ) -> None:
         """Install Open WebUI."""
         try:
             # Check if already installed


### PR DESCRIPTION
## Summary
- add global `.flake8` configuration
- update CI to rely on `.flake8`
- wrap long lines in installer and GUI

## Testing
- `flake8 > /tmp/flake8.log && cat /tmp/flake8.log`
- `flake8 . --select=E9,F63,F7,F82 > /tmp/flake8_sel.log && cat /tmp/flake8_sel.log`
- `flake8 . --count --exit-zero --statistics > /tmp/flake8_stats.log && tail -n 20 /tmp/flake8_stats.log`
- `pytest tests/ --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_685917b9cde08326bd45176553fe2e24