### PR TITLE
Update docs for macOS focus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -106,7 +106,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS focused** - Linux and Windows support planned for the future
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements

--- a/Dockerfile.ai
+++ b/Dockerfile.ai
@@ -341,7 +341,7 @@ Provide context about the Open WebUI Installer project and current task.
 
 ## Notes
 - Keep responses focused on the Open WebUI Installer project
-- Consider Docker, Python, and cross-platform compatibility
+- Consider Docker, Python, and macOS compatibility
 - Maintain code quality and testing standards
 """
 
@@ -523,7 +523,7 @@ RUN cat > /workspace/prompts/code_generation.md << 'EOF'
 
 ## Context
 You are working on the Open WebUI Installer project, which helps users easily install and manage Open WebUI (a user-friendly AI interface). The project should be:
-- Cross-platform (macOS, Linux, Windows)
+- macOS focused (Linux and Windows support planned)
 - Docker-based for isolation
 - User-friendly with clear error messages
 - Well-tested and documented
@@ -581,9 +581,8 @@ RUN cat > /workspace/prompts/debugging.md << 'EOF'
 **Created:** 2024-01-01 00:00:00
 
 ## Context
-You are debugging issues in the Open WebUI Installer project. Focus on:
 - Docker-related issues (common)
-- Cross-platform compatibility problems
+- macOS compatibility problems
 - Network and port conflicts
 - Permission and access issues
 - Installation and dependency problems

--- a/NATIVE_WRAPPER_ANALYSIS.md
+++ b/NATIVE_WRAPPER_ANALYSIS.md
@@ -95,7 +95,7 @@ function createWindow() {
 ```
 
 **Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+- ✅ Focus on macOS (Windows & Linux possible later)
 - ✅ Rich ecosystem and tooling
 - ✅ Easy to add custom features
 - ✅ Familiar to web developers
@@ -124,7 +124,7 @@ fn main() {
 **Advantages:**
 - ✅ Much smaller than Electron (~10-20MB)
 - ✅ Better performance than Electron
-- ✅ Cross-platform
+- ✅ macOS focus with future cross-platform potential
 - ✅ Modern architecture
 
 **Disadvantages:**
@@ -215,7 +215,7 @@ Custom App = Electron + Custom UI + Docker Management + Open WebUI Integration
 **Pros:**
 - ✅ Proven architecture
 - ✅ Rich feature set foundation
-- ✅ Cross-platform
+- ✅ macOS first approach
 
 **Cons:**
 - ❌ Complex to maintain

--- a/ONE_CLICK_REQUIREMENTS.md
+++ b/ONE_CLICK_REQUIREMENTS.md
@@ -98,7 +98,7 @@ Create the **easiest possible installation experience** for Open WebUI on macOS,
 
 ### Option 2: Electron App
 **Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+- ✅ macOS focus today (Windows & Linux possible later)
 - ✅ Web technologies (HTML, CSS, JS)
 - ✅ Rapid development
 - ✅ Rich UI possibilities

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Easy installer and manager for Open WebUI - User-friendly AI Interface
 
+> **Note**: The installer currently targets **macOS**. Linux and Windows support are planned as future backlog items.
+
 ## 🎯 WORKING SETUP (Verified ✅)
 
 **Quick Start - Direct Docker Method:**

--- a/example-private-repo-release.yml
+++ b/example-private-repo-release.yml
@@ -68,7 +68,7 @@ jobs:
 
           ### Installation Methods
 
-          #### Via Homebrew (macOS/Linux) - Recommended
+          #### Via Homebrew (macOS only) - Recommended
           ```bash
           brew tap STEALTHTEMP1/openwebui-installer
           brew install openwebui-installer

--- a/homebrew-tap-template/README.md
+++ b/homebrew-tap-template/README.md
@@ -62,13 +62,13 @@ Open WebUI is a user-friendly web interface for AI models that supports:
 - **One-command installation** - Get Open WebUI running with a single command
 - **Automatic updates** - Keep your installation up-to-date
 - **Service management** - Start, stop, and manage the Open WebUI service
-- **Cross-platform** - Works on macOS, Linux, and Windows (via WSL)
+- **macOS only** - Linux and Windows support planned
 - **Docker support** - Uses Docker for clean, isolated installations
 - **Configuration management** - Easy setup and configuration
 
 ## Requirements
 
-- macOS 10.15+ or Linux
+- macOS 10.15+
 - Docker (will be installed if not present)
 - Internet connection for downloading models and updates
 

--- a/homebrew-tap-template/RELEASE_SETUP.md
+++ b/homebrew-tap-template/RELEASE_SETUP.md
@@ -84,7 +84,7 @@ jobs:
           
           ## Installation
           
-          ### Via Homebrew (macOS/Linux)
+          ### Via Homebrew (macOS only)
           ```bash
           brew tap STEALTHTEMP1/openwebui-installer
           brew install openwebui-installer

--- a/prd.md
+++ b/prd.md
@@ -113,7 +113,7 @@ Final release and docs	September 1, 2025
 ⸻
 
 🔚 12. Out of Scope
-	•	Cross-platform support (Windows/Linux).
+	•	Cross-platform support (Windows/Linux) – planned for a later phase.
 	•	GUI management of containers beyond initial setup.
 	•	Updates/maintenance of installed Docker images (could be added later).
 

--- a/private-repo-setup/setup.sh
+++ b/private-repo-setup/setup.sh
@@ -188,7 +188,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS focused** - Linux and Windows support planned for the future
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+- macOS focused; future Linux and Windows support
 
 ## Installation
 

--- a/setup.sh
+++ b/setup.sh
@@ -188,7 +188,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS focused** - Linux and Windows support planned for the future
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+- macOS focused; future Linux and Windows support
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- document that installer targets macOS
- clarify Homebrew instructions in release workflow and shell scripts
- remove Linux/Windows references in tap templates
- update design docs to reflect macOS focus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859173ba1008326a885c0482572ff9f