### PR TITLE
Add secrets support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      WEBUI_SECRET_KEY: ${{ secrets.WEBUI_SECRET_KEY }}
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
@@ -39,8 +44,13 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      WEBUI_SECRET_KEY: ${{ secrets.WEBUI_SECRET_KEY }}
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      WEBUI_SECRET_KEY: ${{ secrets.WEBUI_SECRET_KEY }}
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ The workflow works with any project structure. It automatically includes all fil
 - `.env` - Environment files
 - `*.log` - Log files
 
+## 🔑 Required Secrets
+
+Set the following secrets in your environment or as Docker secrets:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `HUGGINGFACE_TOKEN`
+- `WEBUI_SECRET_KEY`
+
+These are automatically passed to the container by the installer.
+
+
 ## 🔒 Security & Privacy
 
 - **Your main repository stays private** - Only releases are public

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,9 +20,15 @@ The following secrets must be configured in GitHub repository settings:
 
 2. `HOMEBREW_TAP_TOKEN`: GitHub Personal Access Token
    - Generate at: https://github.com/settings/tokens
-   - Required scopes: 
+   - Required scopes:
      * `repo` (Full control of private repositories)
      * `workflow` (Update GitHub Action workflows)
+
+3. Runtime API keys for installer
+   - `OPENAI_API_KEY`
+   - `ANTHROPIC_API_KEY`
+   - `HUGGINGFACE_TOKEN`
+   - `WEBUI_SECRET_KEY`
 
 ## Release Steps
 

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -14,6 +14,14 @@ from rich.console import Console
 
 console = Console()
 
+# Secrets that can be provided via environment variables or Docker secrets
+SECRET_ENV_VARS = [
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "HUGGINGFACE_TOKEN",
+    "WEBUI_SECRET_KEY",
+]
+
 
 class InstallerError(Exception):
     """Base exception for installer errors."""
@@ -33,6 +41,20 @@ class Installer:
         self.docker_client = docker.from_env()
         self.webui_image = "ghcr.io/open-webui/open-webui:main"  # Default image
         self.config_dir = os.path.expanduser("~/.openwebui")
+
+    def _load_secret(self, name: str) -> Optional[str]:
+        """Retrieve a secret from environment variables or Docker secrets."""
+        value = os.getenv(name)
+        if value:
+            return value
+        secret_path = os.path.join("/run/secrets", name)
+        if os.path.exists(secret_path):
+            try:
+                with open(secret_path) as f:
+                    return f.read().strip()
+            except Exception:
+                return None
+        return None
 
     def _check_system_requirements(self):
         """Validate system requirements."""
@@ -132,14 +154,20 @@ docker run -d \\
                     pass
 
                 # Start new container
+                env_vars = {
+                    "OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"
+                }
+                for secret in SECRET_ENV_VARS:
+                    value = self._load_secret(secret)
+                    if value:
+                        env_vars[secret] = value
+
                 container = self.docker_client.containers.run(
                     current_webui_image,
                     name="open-webui",
                     ports={'8080/tcp': port},
                     volumes={"open-webui": {"bind": "/app/backend/data", "mode": "rw"}},
-                    environment={
-                        "OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"
-                    },
+                    environment=env_vars,
                     extra_hosts={"host.docker.internal": "host-gateway"},
                     detach=True,
                     restart_policy={"Name": "unless-stopped"}


### PR DESCRIPTION
## Summary
- load secrets from env vars or Docker secrets in `Installer`
- document required secrets
- pass secrets via environment to workflows

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685913399f8483268c1c553af475e703