### PR TITLE
Update docs for macOS focus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only; Linux support planned) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -106,7 +106,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS-first** - Linux and Windows support planned
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements

--- a/Dockerfile.ai
+++ b/Dockerfile.ai
@@ -341,7 +341,7 @@ Provide context about the Open WebUI Installer project and current task.
 
 ## Notes
 - Keep responses focused on the Open WebUI Installer project
-- Consider Docker, Python, and cross-platform compatibility
+- Consider Docker, Python, and future cross-platform compatibility
 - Maintain code quality and testing standards
 """
 
@@ -523,7 +523,7 @@ RUN cat > /workspace/prompts/code_generation.md << 'EOF'
 
 ## Context
 You are working on the Open WebUI Installer project, which helps users easily install and manage Open WebUI (a user-friendly AI interface). The project should be:
-- Cross-platform (macOS, Linux, Windows)
+- macOS-first with plans for Linux and Windows support
 - Docker-based for isolation
 - User-friendly with clear error messages
 - Well-tested and documented
@@ -583,7 +583,7 @@ RUN cat > /workspace/prompts/debugging.md << 'EOF'
 ## Context
 You are debugging issues in the Open WebUI Installer project. Focus on:
 - Docker-related issues (common)
-- Cross-platform compatibility problems
+- Future cross-platform compatibility problems
 - Network and port conflicts
 - Permission and access issues
 - Installation and dependency problems

--- a/NATIVE_WRAPPER_ANALYSIS.md
+++ b/NATIVE_WRAPPER_ANALYSIS.md
@@ -94,8 +94,8 @@ function createWindow() {
 }
 ```
 
-**Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+- **Advantages:**
+- ✅ macOS-first (Windows and Linux support planned)
 - ✅ Rich ecosystem and tooling
 - ✅ Easy to add custom features
 - ✅ Familiar to web developers
@@ -124,7 +124,7 @@ fn main() {
 **Advantages:**
 - ✅ Much smaller than Electron (~10-20MB)
 - ✅ Better performance than Electron
-- ✅ Cross-platform
+ - ✅ macOS-first design (cross-platform support planned)
 - ✅ Modern architecture
 
 **Disadvantages:**
@@ -215,7 +215,7 @@ Custom App = Electron + Custom UI + Docker Management + Open WebUI Integration
 **Pros:**
 - ✅ Proven architecture
 - ✅ Rich feature set foundation
-- ✅ Cross-platform
+ - ✅ macOS-first design with planned Linux and Windows support
 
 **Cons:**
 - ❌ Complex to maintain

--- a/ONE_CLICK_REQUIREMENTS.md
+++ b/ONE_CLICK_REQUIREMENTS.md
@@ -98,7 +98,7 @@ Create the **easiest possible installation experience** for Open WebUI on macOS,
 
 ### Option 2: Electron App
 **Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+- ✅ Potential for cross-platform support (Windows/Linux in future)
 - ✅ Web technologies (HTML, CSS, JS)
 - ✅ Rapid development
 - ✅ Rich UI possibilities

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Easy installer and manager for Open WebUI - User-friendly AI Interface
 
+**Supported OS:** macOS (Apple Silicon and Intel). Linux and Windows support are planned for future releases.
+
 ## 🎯 WORKING SETUP (Verified ✅)
 
 **Quick Start - Direct Docker Method:**

--- a/example-private-repo-release.yml
+++ b/example-private-repo-release.yml
@@ -68,7 +68,7 @@ jobs:
 
           ### Installation Methods
 
-          #### Via Homebrew (macOS/Linux) - Recommended
+          #### Via Homebrew (macOS only; Linux support planned) - Recommended
           ```bash
           brew tap STEALTHTEMP1/openwebui-installer
           brew install openwebui-installer

--- a/homebrew-tap-template/README.md
+++ b/homebrew-tap-template/README.md
@@ -62,13 +62,13 @@ Open WebUI is a user-friendly web interface for AI models that supports:
 - **One-command installation** - Get Open WebUI running with a single command
 - **Automatic updates** - Keep your installation up-to-date
 - **Service management** - Start, stop, and manage the Open WebUI service
-- **Cross-platform** - Works on macOS, Linux, and Windows (via WSL)
+- **macOS-first** - Linux and Windows support planned
 - **Docker support** - Uses Docker for clean, isolated installations
 - **Configuration management** - Easy setup and configuration
 
 ## Requirements
 
-- macOS 10.15+ or Linux
+- macOS 10.15+ (Linux support planned)
 - Docker (will be installed if not present)
 - Internet connection for downloading models and updates
 

--- a/homebrew-tap-template/RELEASE_SETUP.md
+++ b/homebrew-tap-template/RELEASE_SETUP.md
@@ -84,7 +84,7 @@ jobs:
           
           ## Installation
           
-          ### Via Homebrew (macOS/Linux)
+          ### Via Homebrew (macOS only; Linux support planned)
           ```bash
           brew tap STEALTHTEMP1/openwebui-installer
           brew install openwebui-installer

--- a/private-repo-setup/.github/workflows/release.yml
+++ b/private-repo-setup/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only; Linux support planned) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -106,7 +106,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS-first** - Linux and Windows support planned
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements

--- a/private-repo-setup/setup.sh
+++ b/private-repo-setup/setup.sh
@@ -188,7 +188,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only; Linux support planned) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS-first** - Linux and Windows support planned
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+- macOS-first; Linux and Windows support planned
 
 ## Installation
 

--- a/setup-codex.sh
+++ b/setup-codex.sh
@@ -514,7 +514,7 @@ When fixing bugs, please:
 4. **Test** the fix comprehensively
 5. **Document** the fix and prevention measures
 
-Consider the installer's cross-platform requirements and Docker integration.
+Consider the installer's future cross-platform requirements and Docker integration.
 EOF
 
     cat > .codex/prompts/feature_development.md << 'EOF'
@@ -525,7 +525,7 @@ When developing new features:
 2. **Implement** following project patterns and conventions
 3. **Test** thoroughly with unit and integration tests
 4. **Document** with clear docstrings and usage examples
-5. **Consider** cross-platform compatibility and Docker integration
+5. **Consider** future cross-platform compatibility and Docker integration
 
 Keep the installer simple, reliable, and user-friendly.
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -188,7 +188,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only; Linux support planned) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **macOS-first** - Linux and Windows support planned
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+- macOS-first; Linux and Windows support planned
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- remove multi-platform references from release workflow and setup scripts
- adjust Homebrew tap docs for macOS-only support
- clarify macOS focus in main docs
- note cross-platform as future work in analysis docs

## Testing
- `pip install pytest-cov`
- `pip install rich`
- `pip install pytest-mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591cce3a2883269fd2e0dc49b79d24