### PR TITLE
Enable Docker integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+
+    - name: Start Docker
+      run: |
+        brew install colima > /dev/null
+        colima start --quiet
+        docker info
         
     - name: Run tests
       run: |


### PR DESCRIPTION
## Summary
- spin up real Docker container in integration tests
- start Docker on macOS CI runners

## Testing
- `pytest tests/test_integration.py -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591ceb3a488326a2c5a279a0b4580d