### PR TITLE
Add container management commands and macOS autostart

### DIFF
--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -34,10 +34,10 @@ def cli():
 
 
 @cli.command()
-@click.option('--model', '-m', help='Ollama model to install', default='llama2')
-@click.option('--port', '-p', help='Port to run Open WebUI on', default=3000, type=int)
-@click.option('--force', '-f', is_flag=True, help='Force installation even if already installed')
-@click.option('--image', help='Custom Open WebUI image to use')
+@click.option("--model", "-m", help="Ollama model to install", default="llama2")
+@click.option("--port", "-p", help="Port to run Open WebUI on", default=3000, type=int)
+@click.option("--force", "-f", is_flag=True, help="Force installation even if already installed")
+@click.option("--image", help="Custom Open WebUI image to use")
 def install(model: str, port: int, force: bool, image: Optional[str]):
     """Install Open WebUI and configure Ollama integration."""
     try:
@@ -87,13 +87,86 @@ def uninstall():
 
 
 @cli.command()
+def start():
+    """Start the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.start()
+        console.print("[green]✓[/green] Open WebUI started")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def stop():
+    """Stop the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.stop()
+        console.print("[green]✓[/green] Open WebUI stopped")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def restart():
+    """Restart the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.restart()
+        console.print("[green]✓[/green] Open WebUI restarted")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+def update():
+    """Update the Open WebUI container."""
+    try:
+        installer = Installer()
+        installer.update()
+        console.print("[green]✓[/green] Open WebUI updated")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.option("--tail", default=100, help="Number of log lines to show")
+def logs(tail: int):
+    """Show logs from the Open WebUI container."""
+    try:
+        installer = Installer()
+        output = installer.logs(tail=tail)
+        console.print(output)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command("enable-autostart")
+def enable_autostart():
+    """Enable autostart on macOS."""
+    try:
+        installer = Installer()
+        path = installer.enable_autostart()
+        console.print(f"[green]✓[/green] Autostart enabled via {path}")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        sys.exit(1)
+
+
+@cli.command()
 def status():
     """Check Open WebUI installation status."""
     try:
         installer = Installer()
         status = installer.get_status()
 
-        if status['installed']:
+        if status["installed"]:
             console.print("[green]✓[/green] Open WebUI is installed")
             console.print(f"Version: {status['version']}")
             console.print(f"Port: {status['port']}")

--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -1,6 +1,7 @@
 """
 Core installer functionality for Open WebUI
 """
+
 import json
 import os
 import platform
@@ -17,11 +18,13 @@ console = Console()
 
 class InstallerError(Exception):
     """Base exception for installer errors."""
+
     pass
 
 
 class SystemRequirementsError(InstallerError):
     """Exception for system requirement validation failures."""
+
     pass
 
 
@@ -64,7 +67,13 @@ class Installer:
         """Ensure configuration directory exists."""
         os.makedirs(self.config_dir, exist_ok=True)
 
-    def install(self, model: str = "llama2", port: int = 3000, force: bool = False, image: Optional[str] = None):
+    def install(
+        self,
+        model: str = "llama2",
+        port: int = 3000,
+        force: bool = False,
+        image: Optional[str] = None,
+    ):
         """Install Open WebUI."""
         try:
             # Check if already installed
@@ -99,7 +108,8 @@ class Installer:
             # Create launch script
             launch_script = os.path.join(self.config_dir, "launch-openwebui.sh")
             with open(launch_script, "w") as f:
-                f.write(f"""#!/bin/bash
+                f.write(
+                    f"""#!/bin/bash
 docker run -d \\
     --name open-webui \\
     -p {port}:8080 \\
@@ -107,7 +117,8 @@ docker run -d \\
     -e OLLAMA_API_BASE_URL=http://host.docker.internal:11434/api \\
     --add-host host.docker.internal:host-gateway \\
     {current_webui_image}
-""")
+"""
+                )
             os.chmod(launch_script, 0o755)
 
             # Create configuration file
@@ -135,14 +146,12 @@ docker run -d \\
                 container = self.docker_client.containers.run(
                     current_webui_image,
                     name="open-webui",
-                    ports={'8080/tcp': port},
+                    ports={"8080/tcp": port},
                     volumes={"open-webui": {"bind": "/app/backend/data", "mode": "rw"}},
-                    environment={
-                        "OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"
-                    },
+                    environment={"OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"},
                     extra_hosts={"host.docker.internal": "host-gateway"},
                     detach=True,
-                    restart_policy={"Name": "unless-stopped"}
+                    restart_policy={"Name": "unless-stopped"},
                 )
                 console.print(f"✓ Container started with ID: {container.short_id}")
 
@@ -165,6 +174,7 @@ docker run -d \\
 
             # Remove configuration
             import shutil
+
             if os.path.exists(self.config_dir):
                 shutil.rmtree(self.config_dir)
 
@@ -197,12 +207,14 @@ docker run -d \\
         try:
             with open(config_file) as f:
                 config = json.load(f)
-                status.update({
-                    "installed": True,
-                    "version": config.get("version"),
-                    "port": config.get("port"),
-                    "model": config.get("model"),
-                })
+                status.update(
+                    {
+                        "installed": True,
+                        "version": config.get("version"),
+                        "port": config.get("port"),
+                        "model": config.get("model"),
+                    }
+                )
         except Exception:
             return status
 
@@ -214,3 +226,110 @@ docker run -d \\
             pass
 
         return status
+
+    def _load_config(self) -> Dict:
+        """Load configuration from disk."""
+        config_file = os.path.join(self.config_dir, "config.json")
+        with open(config_file) as f:
+            return json.load(f)
+
+    def start(self):
+        """Start the Open WebUI Docker container."""
+        if not self.get_status()["installed"]:
+            raise InstallerError("Open WebUI is not installed")
+
+        config = self._load_config()
+        image = config.get("image", self.webui_image)
+        port = config.get("port", 3000)
+
+        try:
+            container = self.docker_client.containers.get("open-webui")
+            if container.status != "running":
+                container.start()
+        except docker.errors.NotFound:
+            self.docker_client.containers.run(
+                image,
+                name="open-webui",
+                ports={"8080/tcp": port},
+                volumes={"open-webui": {"bind": "/app/backend/data", "mode": "rw"}},
+                environment={"OLLAMA_API_BASE_URL": "http://host.docker.internal:11434/api"},
+                extra_hosts={"host.docker.internal": "host-gateway"},
+                detach=True,
+                restart_policy={"Name": "unless-stopped"},
+            )
+        except docker.errors.APIError as e:
+            raise InstallerError(f"Failed to start Open WebUI container: {str(e)}")
+
+    def stop(self):
+        """Stop the Open WebUI Docker container."""
+        try:
+            container = self.docker_client.containers.get("open-webui")
+            container.stop()
+        except docker.errors.NotFound:
+            raise InstallerError("Open WebUI container is not running")
+        except docker.errors.APIError as e:
+            raise InstallerError(f"Failed to stop Open WebUI container: {str(e)}")
+
+    def restart(self):
+        """Restart the Open WebUI Docker container."""
+        try:
+            container = self.docker_client.containers.get("open-webui")
+            container.restart()
+        except docker.errors.NotFound:
+            raise InstallerError("Open WebUI container is not running")
+        except docker.errors.APIError as e:
+            raise InstallerError(f"Failed to restart Open WebUI container: {str(e)}")
+
+    def update(self):
+        """Update the Open WebUI Docker image and restart the container."""
+        if not self.get_status()["installed"]:
+            raise InstallerError("Open WebUI is not installed")
+
+        config = self._load_config()
+        image = config.get("image", self.webui_image)
+
+        try:
+            self.docker_client.images.pull(image)
+            self.restart()
+        except docker.errors.APIError as e:
+            raise InstallerError(f"Failed to update Open WebUI container: {str(e)}")
+
+    def logs(self, tail: int = 100) -> str:
+        """Retrieve logs from the Open WebUI Docker container."""
+        try:
+            container = self.docker_client.containers.get("open-webui")
+            return container.logs(tail=tail).decode()
+        except docker.errors.NotFound:
+            raise InstallerError("Open WebUI container not found")
+
+    def enable_autostart(self) -> str:
+        """Enable autostart on macOS using launchd."""
+        if platform.system() != "Darwin":
+            raise InstallerError("Autostart is only supported on macOS")
+
+        plist_dir = os.path.expanduser("~/Library/LaunchAgents")
+        os.makedirs(plist_dir, exist_ok=True)
+        plist_path = os.path.join(plist_dir, "com.openwebui.autostart.plist")
+        launch_script = os.path.join(self.config_dir, "launch-openwebui.sh")
+        plist_content = f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>Label</key>
+    <string>com.openwebui</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{launch_script}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"""
+        with open(plist_path, "w") as f:
+            f.write(plist_content)
+        try:
+            subprocess.run(["launchctl", "load", "-w", plist_path], check=True)
+        except subprocess.CalledProcessError as e:
+            raise InstallerError(f"Failed to enable autostart: {str(e)}")
+        return plist_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,32 @@
 """
 Tests for the CLI module
 """
-from unittest.mock import MagicMock, patch, Mock
+
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from openwebui_installer.cli import cli, install, uninstall, status
+from openwebui_installer.cli import (
+    cli,
+    enable_autostart,
+    install,
+    logs,
+    restart,
+    start,
+    status,
+    stop,
+    uninstall,
+    update,
+)
 from openwebui_installer.installer import InstallerError, SystemRequirementsError
+
 
 @pytest.fixture
 def runner():
     """Create a CLI test runner."""
     return CliRunner()
+
 
 @pytest.fixture
 def mock_installer():
@@ -22,38 +36,31 @@ def mock_installer():
         mock.return_value = installer
         yield installer
 
+
 def test_version(runner):
     """Test version command."""
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.output.lower()
 
+
 def test_install_success(runner, mock_installer):
     """Test successful installation."""
     result = runner.invoke(cli, ["install"])
     assert result.exit_code == 0
     mock_installer.install.assert_called_once_with(
-        model="llama2",
-        port=3000,
-        force=False,
-        image=None  # Added
+        model="llama2", port=3000, force=False, image=None  # Added
     )
+
 
 def test_install_with_options(runner, mock_installer):
     """Test installation with custom options."""
-    result = runner.invoke(cli, [
-        "install",
-        "--model", "codellama",
-        "--port", "8080",
-        "--force"
-    ])
+    result = runner.invoke(cli, ["install", "--model", "codellama", "--port", "8080", "--force"])
     assert result.exit_code == 0
     mock_installer.install.assert_called_once_with(
-        model="codellama",
-        port=8080,
-        force=True,
-        image=None  # Added
+        model="codellama", port=8080, force=True, image=None  # Added
     )
+
 
 def test_install_system_requirements_error(runner, mock_installer):
     """Test installation with system requirements error."""
@@ -62,6 +69,7 @@ def test_install_system_requirements_error(runner, mock_installer):
     assert result.exit_code == 1
     assert "Docker not running" in result.output
 
+
 def test_install_error(runner, mock_installer):
     """Test installation with general error."""
     mock_installer.install.side_effect = InstallerError("Installation failed")
@@ -69,11 +77,13 @@ def test_install_error(runner, mock_installer):
     assert result.exit_code == 1
     assert "Installation failed" in result.output
 
+
 def test_uninstall_success(runner, mock_installer):
     """Test successful uninstallation."""
     result = runner.invoke(cli, ["uninstall"], input="y\n")
     assert result.exit_code == 0
     mock_installer.uninstall.assert_called_once()
+
 
 def test_uninstall_abort(runner, mock_installer):
     """Test uninstallation abort."""
@@ -81,12 +91,14 @@ def test_uninstall_abort(runner, mock_installer):
     assert result.exit_code == 0
     mock_installer.uninstall.assert_not_called()
 
+
 def test_uninstall_error(runner, mock_installer):
     """Test uninstallation with error."""
     mock_installer.uninstall.side_effect = InstallerError("Uninstall failed")
     result = runner.invoke(cli, ["uninstall"], input="y\n")
     assert result.exit_code == 1
     assert "Uninstall failed" in result.output
+
 
 def test_status_not_installed(runner, mock_installer):
     """Test status command when not installed."""
@@ -100,6 +112,7 @@ def test_status_not_installed(runner, mock_installer):
     result = runner.invoke(cli, ["status"])
     assert result.exit_code == 0
     assert "not installed" in result.output.lower()
+
 
 def test_status_installed_not_running(runner, mock_installer):
     """Test status command when installed but not running."""
@@ -115,6 +128,7 @@ def test_status_installed_not_running(runner, mock_installer):
     assert "installed" in result.output.lower()
     assert "stopped" in result.output.lower()
 
+
 def test_status_installed_and_running(runner, mock_installer):
     """Test status command when installed and running."""
     mock_installer.get_status.return_value = {
@@ -129,12 +143,14 @@ def test_status_installed_and_running(runner, mock_installer):
     assert "installed" in result.output.lower()
     assert "running" in result.output.lower()
 
+
 def test_status_error(runner, mock_installer):
     """Test status command with error."""
     mock_installer.get_status.side_effect = InstallerError("Status check failed")
     result = runner.invoke(cli, ["status"])
     assert result.exit_code == 1
     assert "Status check failed" in result.output
+
 
 class TestCLI:
     def test_install_command(self, runner, mock_installer):
@@ -143,38 +159,41 @@ class TestCLI:
         result = runner.invoke(install)
         assert result.exit_code == 0
         assert "Installation complete!" in result.output
-        
+
         # mock_installer._check_system_requirements.assert_called_once() # This is an internal call of the real Installer.install, not directly by CLI
         mock_installer.install.assert_called_once()
-        
+
         # Test installation failure
         mock_installer.install.side_effect = InstallerError("Installation failed")
         result = runner.invoke(install)
         assert result.exit_code == 1
         assert "Error: Installation failed" in result.output
-        
+
     def test_uninstall_command(self, runner, mock_installer):
         """Test uninstall command"""
         # Test successful uninstallation
-        result = runner.invoke(uninstall, input="y\n") # Added input
+        result = runner.invoke(uninstall, input="y\n")  # Added input
         assert result.exit_code == 0
         assert "Uninstallation complete!" in result.output
-        
-        mock_installer.uninstall.assert_called_once() # Changed from cleanup
-        
+
+        mock_installer.uninstall.assert_called_once()  # Changed from cleanup
+
         # Test uninstallation failure
-        mock_installer.uninstall.reset_mock() # Reset mock
+        mock_installer.uninstall.reset_mock()  # Reset mock
         mock_installer.uninstall.side_effect = InstallerError("Uninstallation failed")
-        result = runner.invoke(uninstall, input="y\n") # Added input
+        result = runner.invoke(uninstall, input="y\n")  # Added input
         assert result.exit_code == 1
         assert "Error: Uninstallation failed" in result.output
-        
+
     def test_status_command(self, runner, mock_installer):
         """Test status command"""
         # Test when Open WebUI is running
-        mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
-            "model": "test", "running": True
+        mock_installer.get_status.return_value = {  # Use get_status
+            "installed": True,
+            "version": "0.1.0",
+            "port": 3000,
+            "model": "test",
+            "running": True,
         }
         result = runner.invoke(status)
         assert result.exit_code == 0
@@ -182,9 +201,12 @@ class TestCLI:
         assert "Status: Running" in result.output
 
         # Test when Open WebUI is not running
-        mock_installer.get_status.return_value = { # Use get_status
-            "installed": True, "version": "0.1.0", "port": 3000,
-            "model": "test", "running": False
+        mock_installer.get_status.return_value = {  # Use get_status
+            "installed": True,
+            "version": "0.1.0",
+            "port": 3000,
+            "model": "test",
+            "running": False,
         }
         result = runner.invoke(status)
         assert result.exit_code == 0
@@ -192,45 +214,82 @@ class TestCLI:
         assert "Status: Stopped" in result.output
 
         # Test status check failure
-        mock_installer.get_status.side_effect = InstallerError("Status check failed") # Use get_status
+        mock_installer.get_status.side_effect = InstallerError(
+            "Status check failed"
+        )  # Use get_status
         result = runner.invoke(status)
         assert result.exit_code == 1
         assert "Error: Status check failed" in result.output
-        
+
     def test_version_option(self, runner):
         """Test --version option"""
-        from openwebui_installer import __version__ # Import to use in test
-        result = runner.invoke(cli, ['--version'])
+        from openwebui_installer import __version__  # Import to use in test
+
+        result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert f"cli, version {__version__}" in result.output # New
-        
+        assert f"cli, version {__version__}" in result.output  # New
+
     def test_help_option(self, runner):
         """Test --help option"""
-        result = runner.invoke(cli, ['--help'])
+        result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
-        assert 'Usage:' in result.output
-        assert 'Options:' in result.output
-        
+        assert "Usage:" in result.output
+        assert "Options:" in result.output
+
     def test_install_with_port_option(self, runner, mock_installer):
         """Test install command with custom port"""
-        result = runner.invoke(install, ['--port', '3001'])
+        result = runner.invoke(install, ["--port", "3001"])
         assert result.exit_code == 0
-        
+
         mock_installer.install.assert_called_once_with(
-            model='llama2', # Default from CLI
-            port=3001,      # Provided in test
-            force=False,    # Default from CLI
-            image=None      # Added
+            model="llama2",  # Default from CLI
+            port=3001,  # Provided in test
+            force=False,  # Default from CLI
+            image=None,  # Added
         )
-        
+
     def test_install_with_image_option(self, runner, mock_installer):
         """Test install command with custom image"""
-        result = runner.invoke(install, ['--image', 'custom/image:tag'])
+        result = runner.invoke(install, ["--image", "custom/image:tag"])
         assert result.exit_code == 0
-        
+
         mock_installer.install.assert_called_once_with(
-            model='llama2',      # Default from CLI
-            port=3000,         # Default from CLI
-            force=False,       # Default from CLI
-            image='custom/image:tag' # Provided in test
+            model="llama2",  # Default from CLI
+            port=3000,  # Default from CLI
+            force=False,  # Default from CLI
+            image="custom/image:tag",  # Provided in test
         )
+
+    def test_start_stop_restart_update_logs_and_autostart(self, runner, mock_installer):
+        """Test additional CLI commands."""
+        # start
+        result = runner.invoke(start)
+        assert result.exit_code == 0
+        mock_installer.start.assert_called_once()
+
+        # stop
+        result = runner.invoke(stop)
+        assert result.exit_code == 0
+        mock_installer.stop.assert_called_once()
+
+        # restart
+        result = runner.invoke(restart)
+        assert result.exit_code == 0
+        mock_installer.restart.assert_called_once()
+
+        # update
+        result = runner.invoke(update)
+        assert result.exit_code == 0
+        mock_installer.update.assert_called_once()
+
+        # logs
+        mock_installer.logs.return_value = "LOGS"
+        result = runner.invoke(logs)
+        assert result.exit_code == 0
+        mock_installer.logs.assert_called_with(tail=100)
+        assert "LOGS" in result.output
+
+        # enable-autostart
+        result = runner.invoke(enable_autostart)
+        assert result.exit_code == 0
+        mock_installer.enable_autostart.assert_called_once()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,7 @@
 """
 Tests for the installer module
 """
+
 import json
 import platform
 import shutil
@@ -9,19 +10,19 @@ from unittest.mock import MagicMock, mock_open
 
 import docker
 import pytest
-from openwebui_installer.installer import (Installer, InstallerError,
-                                           SystemRequirementsError)
+
+from openwebui_installer.installer import Installer, InstallerError, SystemRequirementsError
 
 
 @pytest.fixture
-def installer(tmp_path, mocker): # Added mocker
+def installer(tmp_path, mocker):  # Added mocker
     """Fixture to create a test installer instance with a mocked config directory."""
     config_dir = tmp_path / "openwebui"
     config_dir.mkdir()
 
     # Patch docker.from_env() before Installer is instantiated
     mock_docker_client = MagicMock()
-    mocker.patch('docker.from_env', return_value=mock_docker_client)
+    mocker.patch("docker.from_env", return_value=mock_docker_client)
 
     installer_instance = Installer()
     installer_instance.config_dir = str(config_dir)
@@ -35,10 +36,10 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_success(self, installer, mocker):
         """Test that system requirements check passes on macOS with Docker and Ollama running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
         installer.docker_client.ping.return_value = True
-        mock_requests_get = mocker.patch('requests.get')
+        mock_requests_get = mocker.patch("requests.get")
         mock_requests_get.return_value.status_code = 200
 
         # This should not raise any exception
@@ -46,21 +47,21 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_wrong_os(self, installer, mocker):
         """Test that system requirements check fails on a non-macOS system."""
-        mocker.patch('platform.system', return_value='Linux')
+        mocker.patch("platform.system", return_value="Linux")
         with pytest.raises(SystemRequirementsError, match="This installer only supports macOS"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):
         """Test that system requirements check fails on an old Python version."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 8, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 8, 0))
         with pytest.raises(SystemRequirementsError, match="Python 3.9 or higher is required"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_docker_not_running(self, installer, mocker):
         """Test that system requirements check fails if Docker is not running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
         installer.docker_client.ping.side_effect = Exception("Docker not running")
 
         with pytest.raises(SystemRequirementsError, match="Docker is not running or not installed"):
@@ -68,10 +69,10 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_ollama_not_running(self, installer, mocker):
         """Test that system requirements check fails if Ollama is not running."""
-        mocker.patch('platform.system', return_value='Darwin')
-        mocker.patch('sys.version_info', (3, 9, 0))
+        mocker.patch("platform.system", return_value="Darwin")
+        mocker.patch("sys.version_info", (3, 9, 0))
         installer.docker_client.ping.return_value = True
-        mock_requests_get = mocker.patch('requests.get')
+        mock_requests_get = mocker.patch("requests.get")
         mock_requests_get.side_effect = Exception("Connection failed")
 
         with pytest.raises(SystemRequirementsError, match="Ollama is not installed or not running"):
@@ -79,31 +80,33 @@ class TestInstallerSuite:
 
     def test_install_full_run_success(self, installer, mocker):
         """Test a complete, successful installation run from a clean state."""
-        mocker.patch.object(installer, '_check_system_requirements')
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mock_open_patch = mocker.patch('builtins.open', mock_open())
-        mocker.patch('os.makedirs')
-        mock_json_dump = mocker.patch('json.dump')
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mocker.patch('os.chmod')
+        mocker.patch.object(installer, "_check_system_requirements")
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mock_open_patch = mocker.patch("builtins.open", mock_open())
+        mocker.patch("os.makedirs")
+        mock_json_dump = mocker.patch("json.dump")
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mocker.patch("os.chmod")
 
         installer.install(model="test-model", port=1234, force=False)
 
         installer._check_system_requirements.assert_called_once()
         installer.docker_client.images.pull.assert_called_with(installer.webui_image)
-        mock_subprocess_run.assert_called_with(["ollama", "pull", "test-model"], check=True, timeout=300)
-        assert mock_json_dump.call_args[0][0]['port'] == 1234
-        assert mock_json_dump.call_args[0][0]['model'] == "test-model"
+        mock_subprocess_run.assert_called_with(
+            ["ollama", "pull", "test-model"], check=True, timeout=300
+        )
+        assert mock_json_dump.call_args[0][0]["port"] == 1234
+        assert mock_json_dump.call_args[0][0]["model"] == "test-model"
 
     def test_install_with_custom_image(self, installer, mocker):
         """Test installation with a custom Docker image."""
-        mocker.patch.object(installer, '_check_system_requirements')
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mock_open_patch = mocker.patch('builtins.open', mock_open())
-        mocker.patch('os.makedirs')
-        mock_json_dump = mocker.patch('json.dump')
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mocker.patch('os.chmod')
+        mocker.patch.object(installer, "_check_system_requirements")
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mock_open_patch = mocker.patch("builtins.open", mock_open())
+        mocker.patch("os.makedirs")
+        mock_json_dump = mocker.patch("json.dump")
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mocker.patch("os.chmod")
 
         custom_image = "custom/open-webui:latest"
         installer.install(model="test-model", port=1234, force=False, image=custom_image)
@@ -111,18 +114,20 @@ class TestInstallerSuite:
         installer.docker_client.images.pull.assert_called_with(custom_image)
         # Check that custom image is stored in config
         config_data = mock_json_dump.call_args[0][0]
-        assert config_data['image'] == custom_image
+        assert config_data["image"] == custom_image
 
     def test_install_stops_if_already_installed_without_force(self, installer, mocker):
         """Test that installation stops if already installed and force=False."""
-        mocker.patch.object(installer, 'get_status', return_value={'installed': True})
-        with pytest.raises(InstallerError, match="Open WebUI is already installed. Use --force to reinstall."):
+        mocker.patch.object(installer, "get_status", return_value={"installed": True})
+        with pytest.raises(
+            InstallerError, match="Open WebUI is already installed. Use --force to reinstall."
+        ):
             installer.install(force=False)
 
     def test_uninstall_success(self, installer, mocker):
         """Test a successful uninstall removes container, volume, and config directory."""
-        mock_rmtree = mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True)
+        mock_rmtree = mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)
 
         mock_container = MagicMock()
         mock_volume = MagicMock()
@@ -139,8 +144,8 @@ class TestInstallerSuite:
 
     def test_uninstall_container_and_volume_not_found(self, installer, mocker):
         """Test uninstall when container and volume don't exist."""
-        mock_rmtree = mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True)
+        mock_rmtree = mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)
 
         installer.docker_client.containers.get.side_effect = docker.errors.NotFound("not found")
         installer.docker_client.volumes.get.side_effect = docker.errors.NotFound("not found")
@@ -151,15 +156,15 @@ class TestInstallerSuite:
 
     def test_get_status_not_installed(self, installer, mocker):
         """Test get_status correctly reports not installed when config dir is missing."""
-        mocker.patch('os.path.exists', return_value=False)
+        mocker.patch("os.path.exists", return_value=False)
         status = installer.get_status()
         assert not status["installed"]
 
     def test_get_status_installed_and_running(self, installer, mocker):
         """Test get_status reports correctly when installed and the container is running."""
         mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
-        mocker.patch('builtins.open', mock_open(read_data=mock_file_content))
-        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+        mocker.patch("os.path.exists", return_value=True)
 
         mock_container = MagicMock()
         mock_container.status = "running"
@@ -174,8 +179,8 @@ class TestInstallerSuite:
     def test_get_status_installed_not_running(self, installer, mocker):
         """Test get_status reports correctly when installed but the container is not running."""
         mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
-        mocker.patch('builtins.open', mock_open(read_data=mock_file_content))
-        mocker.patch('os.path.exists', return_value=True)
+        mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+        mocker.patch("os.path.exists", return_value=True)
 
         installer.docker_client.containers.get.side_effect = docker.errors.NotFound("not found")
 
@@ -185,19 +190,23 @@ class TestInstallerSuite:
 
     def test_ensure_config_dir(self, installer, mocker):
         """Test that config directory is created."""
-        mock_makedirs = mocker.patch('os.makedirs')
+        mock_makedirs = mocker.patch("os.makedirs")
         installer._ensure_config_dir()
         mock_makedirs.assert_called_once_with(installer.config_dir, exist_ok=True)
 
     def test_pull_open_webui_failure(self, installer, mocker):
         """Test error handling when pulling the webui image fails during install."""
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mocker.patch.object(installer, '_check_system_requirements') # Mock to prevent its execution
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mocker.patch.object(
+            installer, "_check_system_requirements"
+        )  # Mock to prevent its execution
         # installer.docker_client is already a MagicMock from the fixture.
         installer.docker_client.images.pull.side_effect = docker.errors.APIError("pull failed")
 
-        with pytest.raises(InstallerError, match="Failed to pull Open WebUI Docker image: pull failed"):
-            installer.install(force=False) # Call install, which contains the pull logic
+        with pytest.raises(
+            InstallerError, match="Failed to pull Open WebUI Docker image: pull failed"
+        ):
+            installer.install(force=False)  # Call install, which contains the pull logic
 
     # def test_start_open_webui(self, installer, mocker):
     #     """Test starting Open WebUI container."""
@@ -220,31 +229,35 @@ class TestInstallerSuite:
     def test_pull_ollama_model_failure(self, installer, mocker):
         """Test error handling when pulling an Ollama model fails during install."""
         model_name = "test-model"
-        mocker.patch.object(installer, 'get_status', return_value={'installed': False})
-        mocker.patch.object(installer, '_check_system_requirements')
+        mocker.patch.object(installer, "get_status", return_value={"installed": False})
+        mocker.patch.object(installer, "_check_system_requirements")
         # Mock the docker image pull to prevent it from running
         installer.docker_client.images.pull.return_value = None
 
         # Mock subprocess.run to fail for the ollama pull
-        mock_subprocess_run = mocker.patch('subprocess.run')
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, ["ollama", "pull", model_name])
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            1, ["ollama", "pull", model_name]
+        )
 
         expected_error_message = f"Failed to pull Ollama model {model_name}"
         with pytest.raises(InstallerError, match=expected_error_message):
             installer.install(model=model_name, force=False)
 
         # Ensure subprocess.run was called with the correct model
-        mock_subprocess_run.assert_called_with(["ollama", "pull", model_name], check=True, timeout=300)
+        mock_subprocess_run.assert_called_with(
+            ["ollama", "pull", model_name], check=True, timeout=300
+        )
 
-    def test_stop_open_webui(self, installer, mocker): # Renaming to reflect what it does
+    def test_stop_open_webui(self, installer, mocker):  # Renaming to reflect what it does
         """Test that uninstall stops and removes the container."""
         # installer.docker_client is already a MagicMock from the fixture
         mock_container = MagicMock(name="mock_container")
         installer.docker_client.containers.get.return_value = mock_container
 
         # Mock other parts of uninstall to isolate container stopping
-        mocker.patch('shutil.rmtree')
-        mocker.patch('os.path.exists', return_value=True) # Assume config dir exists
+        mocker.patch("shutil.rmtree")
+        mocker.patch("os.path.exists", return_value=True)  # Assume config dir exists
         installer.docker_client.volumes.get.return_value = MagicMock(name="mock_volume")
 
         installer.uninstall()
@@ -252,6 +265,71 @@ class TestInstallerSuite:
         installer.docker_client.containers.get.assert_called_once_with("open-webui")
         mock_container.stop.assert_called_once()
         mock_container.remove.assert_called_once()
+
+    def test_start_existing_container(self, installer, mocker):
+        """Start should start existing container if not running."""
+        mocker.patch.object(installer, "get_status", return_value={"installed": True})
+        mock_container = MagicMock(status="exited")
+        installer.docker_client.containers.get.return_value = mock_container
+        mocker.patch.object(installer, "_load_config", return_value={"image": "img", "port": 1234})
+        installer.start()
+        mock_container.start.assert_called_once()
+
+    def test_start_new_container_when_missing(self, installer, mocker):
+        """Start should run container if none exists."""
+        mocker.patch.object(installer, "get_status", return_value={"installed": True})
+        installer.docker_client.containers.get.side_effect = docker.errors.NotFound("not found")
+        installer.docker_client.containers.run.return_value = MagicMock()
+        mocker.patch.object(installer, "_load_config", return_value={"image": "img", "port": 1234})
+        installer.start()
+        installer.docker_client.containers.run.assert_called_once()
+
+    def test_stop_container(self, installer, mocker):
+        """Stop should stop running container."""
+        mock_container = MagicMock()
+        installer.docker_client.containers.get.return_value = mock_container
+        installer.stop()
+        mock_container.stop.assert_called_once()
+
+    def test_restart_container(self, installer, mocker):
+        """Restart should restart running container."""
+        mock_container = MagicMock()
+        installer.docker_client.containers.get.return_value = mock_container
+        installer.restart()
+        mock_container.restart.assert_called_once()
+
+    def test_update_pulls_image_and_restarts(self, installer, mocker):
+        """Update should pull image and restart container."""
+        mocker.patch.object(installer, "get_status", return_value={"installed": True})
+        mocker.patch.object(installer, "_load_config", return_value={"image": "img"})
+        mock_restart = mocker.patch.object(installer, "restart")
+        installer.update()
+        installer.docker_client.images.pull.assert_called_once_with("img")
+        mock_restart.assert_called_once()
+
+    def test_logs_returns_string(self, installer, mocker):
+        """Logs should return decoded string."""
+        mock_container = MagicMock()
+        mock_container.logs.return_value = b"hello"
+        installer.docker_client.containers.get.return_value = mock_container
+        output = installer.logs()
+        assert output == "hello"
+
+    def test_enable_autostart_creates_plist(self, installer, mocker, tmp_path):
+        """Enable autostart should write plist on macOS."""
+        mocker.patch("platform.system", return_value="Darwin")
+        plist_dir = tmp_path / "Library" / "LaunchAgents"
+        mocker.patch(
+            "os.path.expanduser",
+            side_effect=lambda p: str(plist_dir.parent) if p.startswith("~/") else p,
+        )
+        mocker.patch("os.makedirs")
+        mock_run = mocker.patch("subprocess.run")
+        plist_path = plist_dir / "com.openwebui.autostart.plist"
+        mock_open_file = mocker.patch("builtins.open", mock_open())
+        result = installer.enable_autostart()
+        assert result.endswith("com.openwebui.autostart.plist")
+        mock_run.assert_called_once()
 
     # def test_is_open_webui_running(self, installer, mocker):
     #     """Test checking if open webui is running."""


### PR DESCRIPTION
## Summary
- extend installer with start/stop/restart/update/logs helpers
- add macOS autostart via launchd
- expose new CLI commands including enable-autostart
- add tests for CLI and installer covering new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591e87a2948326b7e79e21139b09c5