### PR TITLE
Add GHCR build and usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,29 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics 
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  build-and-push:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push dev image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile.dev
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/openwebui-installer-dev:latest

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -36,6 +36,7 @@ This guide helps you set up and use the complete development environment for the
 - **AI development container** with Jupyter Lab
 - **Documentation server** (Sphinx + HTTP server)
 - **Monitoring stack** (Prometheus + Grafana)
+- **Prebuilt dev image** from GitHub Container Registry
 
 ## Setup Scripts
 
@@ -133,6 +134,17 @@ mypy .
 python install.py --help
 pytest tests/
 black --check .
+```
+
+### GitHub Container Registry
+
+The development image is built by CI and published to GHCR as
+`ghcr.io/stealthtemp1/openwebui-installer-dev:latest`. The compose file pulls
+this image automatically, so the environment starts quickly without a local
+build.
+
+```bash
+docker compose -f docker-compose.dev.yml pull dev-environment
 ```
 
 ### 3. AI-Assisted Development

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,7 @@
 services:
   # Main development environment
   dev-environment:
+    image: ghcr.io/stealthtemp1/openwebui-installer-dev:latest
     build:
       context: .
       dockerfile: Dockerfile.dev


### PR DESCRIPTION
## Summary
- build `Dockerfile.dev` in CI and push to GHCR
- pull the prebuilt image in `docker-compose.dev.yml`
- document GHCR registry usage for the development image

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591f93a4c8832687a3eaf23fd0caca