### PR TITLE
Document macOS-only support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,7 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Target Platform**
-- [ ] macOS
+- [x] macOS
 - [ ] Linux (future)
 - [ ] Windows (future)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
           ### Installation Methods
 
-          #### 🍺 Via Homebrew (macOS/Linux) - **Recommended**
+          #### 🍺 Via Homebrew (macOS only) - **Recommended**
           ```bash
           # Add the tap
           brew tap STEALTHTEMP1/openwebui-installer
@@ -106,7 +106,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **Platform support** - Currently macOS only (Linux and Windows planned)
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements

--- a/NATIVE_WRAPPER_ANALYSIS.md
+++ b/NATIVE_WRAPPER_ANALYSIS.md
@@ -4,6 +4,8 @@
 
 Instead of rebuilding Open WebUI's interface natively, **wrap the existing web interface** in a native macOS application with **bundled container runtime**. This approach leverages Open WebUI's excellent web UI while providing native macOS integration and **making Docker completely invisible** to users.
 
+**Note:** Current focus is macOS only. Linux and Windows wrappers are future roadmap items.
+
 ## 🚀 Why Level 3 Complete Abstraction is Revolutionary
 
 ### ✅ Advantages
@@ -95,7 +97,7 @@ function createWindow() {
 ```
 
 **Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+ - ✅ Platform support: currently macOS only (Linux and Windows planned)
 - ✅ Rich ecosystem and tooling
 - ✅ Easy to add custom features
 - ✅ Familiar to web developers
@@ -124,7 +126,7 @@ fn main() {
 **Advantages:**
 - ✅ Much smaller than Electron (~10-20MB)
 - ✅ Better performance than Electron
-- ✅ Cross-platform
+ - ✅ Platform support: currently macOS only (Linux and Windows planned)
 - ✅ Modern architecture
 
 **Disadvantages:**
@@ -215,7 +217,7 @@ Custom App = Electron + Custom UI + Docker Management + Open WebUI Integration
 **Pros:**
 - ✅ Proven architecture
 - ✅ Rich feature set foundation
-- ✅ Cross-platform
+ - ✅ Platform support: currently macOS only (Linux and Windows planned)
 
 **Cons:**
 - ❌ Complex to maintain

--- a/ONE_CLICK_REQUIREMENTS.md
+++ b/ONE_CLICK_REQUIREMENTS.md
@@ -4,6 +4,8 @@
 
 Create the **easiest possible installation experience** for Open WebUI on macOS, targeting **novice users** who want AI functionality without technical complexity.
 
+**Note:** The one-click installer currently supports only macOS. Linux and Windows support are planned for the future.
+
 **Vision**: Download one file, double-click, and have Open WebUI running in under 30 seconds with **Level 3 Complete Abstraction** - making Docker completely invisible to users.
 
 ## 👥 Target User Profile
@@ -98,7 +100,7 @@ Create the **easiest possible installation experience** for Open WebUI on macOS,
 
 ### Option 2: Electron App
 **Advantages:**
-- ✅ Cross-platform (Mac, Windows, Linux)
+ - ✅ Platform support: currently macOS only (Linux and Windows planned)
 - ✅ Web technologies (HTML, CSS, JS)
 - ✅ Rapid development
 - ✅ Rich UI possibilities

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Easy installer and manager for Open WebUI - User-friendly AI Interface
 
+**Note:** This installer currently supports only macOS. Linux and Windows support are on the roadmap.
+
 ## 🎯 WORKING SETUP (Verified ✅)
 
 **Quick Start - Direct Docker Method:**

--- a/homebrew-tap-template/README.md
+++ b/homebrew-tap-template/README.md
@@ -62,7 +62,7 @@ Open WebUI is a user-friendly web interface for AI models that supports:
 - **One-command installation** - Get Open WebUI running with a single command
 - **Automatic updates** - Keep your installation up-to-date
 - **Service management** - Start, stop, and manage the Open WebUI service
-- **Cross-platform** - Works on macOS, Linux, and Windows (via WSL)
+ - **Platform support** - Currently macOS only (Linux and Windows planned)
 - **Docker support** - Uses Docker for clean, isolated installations
 - **Configuration management** - Easy setup and configuration
 

--- a/private-repo-setup/setup.sh
+++ b/private-repo-setup/setup.sh
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **Platform support** - Currently macOS only (Linux and Windows planned)
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+ - Platform support: currently macOS only (Linux and Windows planned)
 
 ## Installation
 

--- a/setup.sh
+++ b/setup.sh
@@ -220,7 +220,7 @@ jobs:
           - **Automatic updates** - Keep your installation current
           - **Service management** - Start, stop, restart Open WebUI easily
           - **Docker support** - Clean, isolated installations
-          - **Multi-platform** - Works on macOS, Linux, and Windows (via WSL)
+          - **Platform support** - Currently macOS only (Linux and Windows planned)
           - **Configuration management** - Easy setup and customization
 
           ### 📋 Requirements
@@ -384,7 +384,7 @@ Easy installer and manager for Open WebUI - A user-friendly AI interface.
 - Automatic updates
 - Service management
 - Docker support
-- Multi-platform compatibility
+ - Platform support: currently macOS only (Linux and Windows planned)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- clarify macOS-only support in README and documentation
- mark Linux and Windows as future roadmap items
- update installer features in setup scripts and Homebrew README
- enable only macOS in feature request template
- note macOS-only support in GitHub release workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591f9094ec8326bcc37c3046f2f15e