### PR TITLE
Update CI to run tests on ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']


### PR DESCRIPTION
## Summary
- run CI tests on ubuntu-latest instead of macOS

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_685920b30e10832690b1b100457880d9