### PR TITLE
Add _ensure_config_dir to installer

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -62,6 +62,9 @@ class Installer:
         self.webui_image = "ghcr.io/open-webui/open-webui:main"
         self.config_dir = os.path.expanduser("~/.openwebui")
 
+        # Ensure configuration directory exists before setting up logging
+        self._ensure_config_dir()
+
         # Initialize Docker client with runtime fallback
         try:
             self.docker_client = docker.from_env()
@@ -114,6 +117,10 @@ class Installer:
             )
             logger.addHandler(handler)
             logger.setLevel(logging.INFO)
+
+    def _ensure_config_dir(self) -> None:
+        """Create the configuration directory if it does not already exist."""
+        os.makedirs(self.config_dir, exist_ok=True)
 
     def _podman_available(self) -> bool:
         """Check if Podman is installed."""


### PR DESCRIPTION
## Summary
- ensure configuration directory exists at initialization
- implement `_ensure_config_dir` helper

## Testing
- `pytest tests/test_installer.py::TestInstallerSuite::test_ensure_config_dir -q`

------
https://chatgpt.com/codex/tasks/task_e_685bcc927a9c8326b3d016f331021ecb