### PR TITLE
Fix container cleanup

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -270,8 +270,12 @@ class Installer:
 
         try:
             container = self.docker_client.containers.get("open-webui")
-            if container.status == "running":
+            try:
+                # Attempt to stop the container regardless of current status
                 container.stop()
+            except docker.errors.APIError:
+                # Ignore errors if the container is already stopped or not running
+                pass
             container.remove()
             if self.verbose:
                 logger.info("Stopped and removed existing container")


### PR DESCRIPTION
## Summary
- ensure stop() is called unconditionally in `_stop_existing_container`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685bccb8be18832683004eb76a92f827