### PR TITLE
Pin monitoring image versions

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-environment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Verify Docker installation
         run: |

--- a/CROSS_PLATFORM_SETUP.md
+++ b/CROSS_PLATFORM_SETUP.md
@@ -4,7 +4,7 @@ This guide outlines the recommended steps to prepare a development environment o
 
 ## Requirements
 
-- **Python 3.9+**
+- **Python 3.11.13** (same version used by CI and Docker images)
 - **Docker** (Docker Desktop or compatible engine)
 - `bash`, `curl`, and common build tools
 

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -139,7 +139,7 @@ black --check .
 ### GitHub Container Registry
 
 The development image is built by CI and published to GHCR as
-`ghcr.io/stealthtemp1/openwebui-installer-dev:latest`. The compose file pulls
+`ghcr.io/stealthtemp1/openwebui-installer-dev:v1`. The compose file pulls
 this image automatically, so the environment starts quickly without a local
 build.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 services:
   # Main development environment
   dev-environment:
-    image: ghcr.io/stealthtemp1/openwebui-installer-dev:latest
+    image: ghcr.io/stealthtemp1/openwebui-installer-dev:v1
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -137,7 +137,7 @@ services:
 
   # Performance monitoring
   monitoring:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.4.1
     container_name: openwebui-monitoring
     ports:
       - "9090:9090"
@@ -151,7 +151,7 @@ services:
 
   # Log aggregation
   logs:
-    image: grafana/loki:latest
+    image: grafana/loki:3.5.1
     container_name: openwebui-logs
     ports:
       - "3100:3100"
@@ -164,7 +164,7 @@ services:
 
   # Development dashboard
   dashboard:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.0.2
     container_name: openwebui-dashboard
     ports:
       - "3000:3000"

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -23,7 +23,7 @@ services:
       start_period: 40s
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.53.0
     container_name: cadvisor
     volumes:
       - /:/rootfs:ro
@@ -35,7 +35,7 @@ services:
     restart: always
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.4.1
     container_name: prometheus
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
@@ -46,7 +46,7 @@ services:
     restart: always
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.0.2
     container_name: grafana
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -134,7 +134,7 @@ services:
 
   # Performance monitoring
   monitoring:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.4.1
     container_name: openwebui-monitoring
     ports:
       - "9090:9090"
@@ -148,7 +148,7 @@ services:
 
   # Log aggregation
   logs:
-    image: grafana/loki:latest
+    image: grafana/loki:3.5.1
     container_name: openwebui-logs
     ports:
       - "3100:3100"
@@ -161,7 +161,7 @@ services:
 
   # Development dashboard
   dashboard:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.0.2
     container_name: openwebui-dashboard
     ports:
       - "3000:3000"

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -15,7 +15,7 @@ resource "docker_volume" "grafana_data" {
 
 resource "docker_container" "prometheus" {
   name  = "prometheus"
-  image = "prom/prometheus:latest"
+  image = "prom/prometheus:v3.4.1"
 
   ports {
     internal = 9090
@@ -30,7 +30,7 @@ resource "docker_container" "prometheus" {
 
 resource "docker_container" "grafana" {
   name  = "grafana"
-  image = "grafana/grafana:latest"
+  image = "grafana/grafana:12.0.2"
 
   env = ["GF_SECURITY_ADMIN_PASSWORD=admin"]
 


### PR DESCRIPTION
## Summary
- pin Prometheus, Loki and Grafana versions in Docker Compose files and Terraform
- pin cadvisor version
- update dev compose to use GHCR image v1
- pin runner version in preflight workflow
- note Python version in cross-platform setup guide
- adjust dev environment guide accordingly

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -k "not gui" -q` *(fails: AttributeError, ConnectionRefusedError, AssertionError)*


------
https://chatgpt.com/codex/tasks/task_e_685bcce9b4f08326b2453de124c6d183