### PR TITLE
Add bootstrap and cleanup scripts

### DIFF
--- a/OpenWebUI-Desktop/README.md
+++ b/OpenWebUI-Desktop/README.md
@@ -60,7 +60,12 @@ git clone https://github.com/STEALTHTEMP1/openwebui-installer.git
 cd openwebui-installer/OpenWebUI-Desktop
 ```
 
-2. **Download Runtime Components** ⚠️ **Required Step**
+2. **Bootstrap Environment**
+```bash
+../scripts/bootstrap.sh
+```
+
+3. **Download Runtime Components** ⚠️ **Required Step**
 ```bash
 # Make script executable
 chmod +x Scripts/bundle-resources.sh
@@ -74,17 +79,17 @@ chmod +x Scripts/bundle-resources.sh
 
 > **📝 Note**: The large bundled runtime files (Podman binary ~41MB, OpenWebUI image ~1.5GB) are not included in the git repository due to GitHub's 100MB file size limit. You must run the `bundle-resources.sh` script to download these components locally before building the app.
 
-3. **Open in Xcode**
+4. **Open in Xcode**
 ```bash
 open OpenWebUI-Desktop.xcodeproj
 ```
 
-4. **Configure Code Signing**
+5. **Configure Code Signing**
    - Select your Development Team in project settings
    - Update Bundle Identifier if needed
    - Ensure "Automatically manage signing" is enabled
 
-5. **Build and Run**
+6. **Build and Run**
    - Product → Build (⌘B)
    - Product → Run (⌘R)
 
@@ -221,6 +226,7 @@ xattr -cr /Applications/OpenWebUI.app
 2. Check Activity Monitor for resource usage
 3. Restart the app to reset container
 4. Ensure you have adequate free disk space
+5. Run `../scripts/clean-xcode.sh` to clear caches and verify the runtime
 
 ### Diagnostic Tools
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bootstrap.sh - Prepare development environment for OpenWebUI Desktop
+# Installs Homebrew, Python3 and Podman if missing, syncs Bundled-Runtime,
+# and opens the Xcode project on macOS.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+XCODE_DIR="$PROJECT_ROOT/OpenWebUI-Desktop"
+BUNDLE_SCRIPT="$XCODE_DIR/Scripts/bundle-resources.sh"
+
+check_brew() {
+    if ! command -v brew >/dev/null 2>&1; then
+        log_info "Installing Homebrew..."
+        NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        if [[ "$OSTYPE" == "linux"* ]]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> "$HOME/.bashrc"
+        fi
+    else
+        log_success "Homebrew found: $(brew --version | head -1)"
+    fi
+}
+
+check_python() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        log_info "Installing Python3..."
+        if command -v brew >/dev/null 2>&1; then
+            brew install python
+        elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y python3 python3-venv
+        else
+            log_error "No supported package manager found for installing Python3"
+            exit 1
+        fi
+    else
+        log_success "Python3 found: $(python3 --version)"
+    fi
+}
+
+check_podman() {
+    if ! command -v podman >/dev/null 2>&1; then
+        log_info "Installing Podman..."
+        if command -v brew >/dev/null 2>&1; then
+            brew install podman
+        elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y podman
+        else
+            log_error "No supported package manager found for installing Podman"
+            exit 1
+        fi
+    else
+        log_success "Podman found: $(podman --version)"
+    fi
+}
+
+sync_runtime() {
+    if [[ -x "$BUNDLE_SCRIPT" ]]; then
+        log_info "Syncing Bundled-Runtime..."
+        if "$BUNDLE_SCRIPT" --verify; then
+            log_success "Runtime already up to date"
+        else
+            "$BUNDLE_SCRIPT"
+        fi
+    else
+        log_warn "bundle-resources.sh not found, skipping runtime sync"
+    fi
+}
+
+open_project() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        log_info "Opening Xcode project..."
+        open "$XCODE_DIR/OpenWebUI-Desktop.xcodeproj"
+    else
+        log_info "Bootstrap complete. Open the Xcode project manually:"
+        echo "$XCODE_DIR/OpenWebUI-Desktop.xcodeproj"
+    fi
+}
+
+main() {
+    echo "🚀 OpenWebUI Desktop Bootstrap"
+    echo "=============================="
+    check_brew
+    check_python
+    check_podman
+    sync_runtime
+    open_project
+}
+
+main "$@"

--- a/scripts/clean-xcode.sh
+++ b/scripts/clean-xcode.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# clean-xcode.sh - Remove Xcode cache directories and verify bundled runtime
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+BUNDLE_SCRIPT="$PROJECT_ROOT/OpenWebUI-Desktop/Scripts/bundle-resources.sh"
+
+clean_dir() {
+    local dir="$1"
+    if [[ -d "$dir" ]]; then
+        rm -rf "$dir"
+        log_success "Removed $dir"
+    else
+        log_info "No $dir directory found"
+    fi
+}
+
+main() {
+    echo "🧹 Cleaning Xcode caches"
+    echo "======================="
+
+    clean_dir "$HOME/Library/Developer/Xcode/DerivedData"
+    clean_dir "$HOME/Library/Caches/com.apple.dt.Xcode"
+
+    if [[ -x "$BUNDLE_SCRIPT" && "$OSTYPE" == "darwin"* ]]; then
+        log_info "Validating Bundled-Runtime..."
+        if "$BUNDLE_SCRIPT" --verify; then
+            log_success "Runtime bundle verified"
+        else
+            log_error "Runtime bundle verification failed"
+        fi
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- create `scripts/bootstrap.sh` for installing prerequisites and syncing runtime
- add `scripts/clean-xcode.sh` for clearing caches and verifying resources
- document new scripts in `OpenWebUI-Desktop/README.md`

## Testing
- `python3 -m pip install -r requirements-dev.txt`
- `QT_QPA_PLATFORM=offscreen pytest tests` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685bd161684883269099e9f02da11622