### PR TITLE
Configure Codex network access

### DIFF
--- a/.codexrc
+++ b/.codexrc
@@ -1,3 +1,4 @@
 test = xvfb-run -a bash -c 'export QT_QPA_PLATFORM=offscreen; pytest -q'
 lint = flake8 .
 build = python -m build
+allow_network = true


### PR DESCRIPTION
## Summary
- allow network calls in Codex
- run network diagnostics to verify access

## Testing
- `xvfb-run -a bash -c 'export QT_QPA_PLATFORM=offscreen; pytest -q'` *(fails: ModuleNotFoundError: No module named 'rich')*
- `flake8 .` *(fails: numerous style violations)*
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_685bd385341c8326b2cb9fdc69bf50a0