### PR TITLE
Remove obsolete branch cleanup scripts from docs

### DIFF
--- a/.github/BRANCH_PROTECTION_SETUP.md
+++ b/.github/BRANCH_PROTECTION_SETUP.md
@@ -97,13 +97,11 @@ Never use these patterns for feature branches:
 1. **Weekly Cleanup**: Automated workflow runs every Sunday at 2 AM UTC
 2. **Auto-delete**: GitHub automatically deletes merged branches
 3. **Security Scanning**: Automated security checks on all PRs
+4. **Branch Cleanup Workflow**: See `.github/workflows/branch-cleanup.yml`
 
 ### Manual Cleanup Commands
 
 ```bash
-# Run assessment
-./scripts/branch_cleanup_assessment.sh
-
 # View current branch status
 git branch -r | wc -l
 git branch -r --merged main | grep -v 'main\|master\|HEAD'
@@ -151,7 +149,7 @@ git branch -r --merged main | grep 'codex/' | sed 's/origin\///' | xargs -I {} g
 **Solution**: Verify "Automatically delete head branches" is enabled in repository settings
 
 **Problem**: Too many stale branches
-**Solution**: Run manual cleanup script: `./scripts/branch_cleanup_assessment.sh`
+**Solution**: Trigger the **Branch Cleanup** workflow or prune branches manually
 
 ### Emergency Procedures
 
@@ -184,7 +182,7 @@ This setup works with the following repository files:
 
 - `.github/workflows/branch-cleanup.yml` - Automated cleanup
 - `.github/workflows/ci.yml` - Status checks
-- `scripts/branch_cleanup_assessment.sh` - Manual cleanup tool
+- `.github/workflows/branch-cleanup.yml` - Automated cleanup
 - `CODEOWNERS` - Code review assignments (optional)
 
 ## Compliance and Auditing

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -80,13 +80,13 @@ Configure GitHub to automatically:
 
 ### 1. Manual Branch Review Process
 
-```bash
-# Run the assessment script
-./scripts/branch_cleanup_assessment.sh
+Use the GitHub Actions **Branch Cleanup** workflow for a comprehensive
+analysis. It can be triggered manually from the **Actions** tab or run
+on its weekly schedule.
 
-# Review the generated files
-cat .branch-analysis/cleanup-*/branch_cleanup_report.md
-cat .branch-analysis/cleanup-*/active_branches.txt
+```bash
+# List merged branches locally for a quick review
+git branch -r --merged main | grep -v 'main\|master\|HEAD'
 ```
 
 ### 2. Branch Triage Workflow
@@ -120,13 +120,14 @@ Never delete branches that:
 - ❌ Are referenced in open issues/PRs
 - ❌ Represent ongoing work
 
-### 4. Automated Cleanup Script
+### 4. Automated Cleanup
+
+Branch cleanup is handled by the workflow
+`.github/workflows/branch-cleanup.yml`. It runs weekly and can also be
+triggered manually.
 
 ```bash
-# Generated cleanup script (safe branches only)
-.branch-analysis/cleanup-*/cleanup_merged_branches.sh
-
-# Manual review before deletion
+# Review history before deleting a branch
 git log --graph --oneline main..origin/BRANCH_NAME
 ```
 
@@ -225,8 +226,8 @@ git push origin BRANCH_NAME
 
 ## Tools and Scripts
 
-### Available Scripts
-- `scripts/branch_cleanup_assessment.sh` - Comprehensive branch analysis
+### Available Tools
+- `.github/workflows/branch-cleanup.yml` - Automated branch cleanup
 - `scripts/auto_merge_safe.sh` - Automatic merging of safe branches
 - `scripts/enhanced_branch_analyzer.sh` - Detailed branch categorization
 - `scripts/post_merge_validation.sh` - Post-merge validation and testing
@@ -234,9 +235,9 @@ git push origin BRANCH_NAME
 ### Usage Examples
 
 ```bash
-# Full assessment and cleanup
-./scripts/branch_cleanup_assessment.sh
-./scripts/auto_merge_safe.sh
+# Trigger the cleanup workflow manually (optional)
+# This can also be scheduled via GitHub Actions
+gh workflow run branch-cleanup.yml
 
 # Manual merge with validation
 git merge origin/BRANCH_NAME

--- a/BRANCH_MANAGEMENT_SUMMARY.md
+++ b/BRANCH_MANAGEMENT_SUMMARY.md
@@ -28,13 +28,12 @@ All merged branches were safely deleted, including:
 
 ## 🛠️ Tools Created
 
-### 1. Branch Cleanup Assessment (`scripts/branch_cleanup_assessment.sh`)
-- **Purpose**: Analyze repository and identify branches for cleanup
-- **Features**: 
-  - Categorizes branches by type and merge status
-  - Identifies safe-to-delete branches
-  - Generates cleanup scripts and reports
-  - Creates backups before deletion
+### 1. Branch Cleanup Workflow (`.github/workflows/branch-cleanup.yml`)
+- **Purpose**: Automatically remove merged branches
+- **Features**:
+  - Runs weekly or on demand
+  - Supports dry-run mode
+  - Provides a cleanup report
 
 ### 2. Branch Maintenance Tool (`scripts/branch_maintenance.sh`)
 - **Purpose**: Ongoing branch management and monitoring

--- a/BRANCH_MERGE_SUMMARY.md
+++ b/BRANCH_MERGE_SUMMARY.md
@@ -155,7 +155,7 @@ The automated duplicate detection didn't find exact duplicates, but manual revie
 
 ### 📋 Analysis Scripts
 - `scripts/systematic_branch_review.sh` - Comprehensive branch analysis
-- `scripts/branch_cleanup_assessment.sh` - Cleanup recommendations
+- `.github/workflows/branch-cleanup.yml` - Cleanup recommendations
 - `scripts/branch_maintenance.sh` - Ongoing maintenance tools
 
 ### 🔧 Merge Scripts  

--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -26,20 +26,13 @@ This document describes how to keep your repository clean of stale/merged branch
 
 ## 2. Manual Branch Analysis and Cleanup
 
-Scripts in `scripts/` allow you to analyze and clean branches interactively:
+Use the **Branch Cleanup** workflow to safely remove merged branches. It can be
+triggered from the GitHub Actions tab with a dry-run option.
 
-- **Analyze merged/unmerged branches:**  
-  `./scripts/branch_cleanup_assessment.sh`  
-  This generates a report under `.branch-analysis/cleanup-YYYYMMDD_HHMMSS/`.  
-
-- **Review report:**  
-  The generated Markdown report explains which branches are safe to delete and provides a script to do so.
-
-- **Execute the recommended cleanup:**  
-  Run the generated shell script (e.g., `.branch-analysis/cleanup-YYYYMMDD_HHMMSS/cleanup_merged_branches.sh`).
-
-- **Safety:**  
-  Each cleanup generates backups of current branches, and always asks for confirmation before deleting anything.
+```bash
+# Manually list merged branches for review
+git branch -r --merged main | grep -v 'main\|master\|HEAD'
+```
 
 ---
 

--- a/repo-restructure-plan/REPO_RESTRUCTURE_PLAN.md
+++ b/repo-restructure-plan/REPO_RESTRUCTURE_PLAN.md
@@ -84,7 +84,6 @@ REMOVE/PRIVATE:
 ├── .branch-analysis/ (entire directory)
 ├── scripts/
 │   ├── auto_merge_safe.sh
-│   ├── branch_cleanup_assessment.sh
 │   ├── branch_maintenance.sh
 │   ├── enhanced_branch_analyzer.sh
 │   ├── merge_critical_branches.sh

--- a/repo-restructure-plan/restructure-repo.sh
+++ b/repo-restructure-plan/restructure-repo.sh
@@ -76,7 +76,6 @@ main() {
 # Branch Analysis and Management
 .branch-analysis/
 scripts/auto_merge_safe.sh
-scripts/branch_cleanup_assessment.sh
 scripts/branch_maintenance.sh
 scripts/enhanced_branch_analyzer.sh
 scripts/merge_critical_branches.sh

--- a/repo-restructure-plan/validate-restructure.sh
+++ b/repo-restructure-plan/validate-restructure.sh
@@ -152,7 +152,6 @@ check_no_private_files() {
 
     local private_files=(
         ".branch-analysis"
-        "scripts/branch_cleanup_assessment.sh"
         "scripts/merge_safe_branches.sh"
         "BRANCH_MANAGEMENT.md"
         "DEVELOPMENT_TEAM_GUIDE.md"


### PR DESCRIPTION
## Summary
- update branch management docs to refer to GitHub Actions workflow
- revise branch protection setup instructions
- clean up cleanup documentation
- drop references from summary and merge docs
- adjust repo restructure plan scripts

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: Installation failed: Failed to pull Ollama model)*

------
https://chatgpt.com/codex/tasks/task_e_685cebe8fe548326a81495508db44ff7