### PR TITLE
Clarify macOS-only support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Formerly **Open WebUI Installer**, this project is evolving into a **Universal Container App Store**. The goal is to provide a streamlined way to install and manage containerized applications—including Open WebUI—through a single interface.
 
+Currently the App Store is packaged only for **macOS**, with cross-platform support planned.
+
 
 ## 🎯 Quick Start (Docker)
 


### PR DESCRIPTION
## Summary
- note macOS-only packaging for the Universal Container App Store

## Testing
- `pip install -r requirements-dev.txt`
- `pip install python-dotenv`
- `python -m pytest -q` *(fails: ModuleNotFoundError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb8b59c48326a870434ee28eb592