### PR TITLE
Ensure python-dotenv installed for tests

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -18,6 +18,10 @@ This guide helps you set up and use the complete development environment for the
 ./dev.sh test
 ```
 
+The `setup-codex.sh` script installs all Python dependencies from
+`requirements-dev.txt` (including `python-dotenv`) so tests can load
+environment variables automatically.
+
 ## Environment Components
 
 ### 🧠 Codex Development Setup

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,7 +19,12 @@ git clone https://github.com/STEALTHTEMP1/openwebui-installer.git
 cd openwebuiinstaller
 ```
 
-### 2. Start Development Environment
+### 2. Install Dependencies
+```bash
+pip install -r requirements-dev.txt  # includes python-dotenv for tests
+```
+
+### 3. Start Development Environment
 ```bash
 ./dev.sh start
 ```
@@ -29,7 +34,7 @@ This will:
 - 🚀 Start all services (database, Redis, development environment)
 - ✅ Set up the complete development stack
 
-### 3. Verify Everything Works
+### 4. Verify Everything Works
 ```bash
 # Check status
 ./dev.sh status
@@ -41,7 +46,7 @@ This will:
 ./dev.sh exec "python -m pytest tests/ -v"
 ```
 
-### 4. Launch Open WebUI
+### 5. Launch Open WebUI
 
 Outside of the dev container you can start Open WebUI using the same Docker command described in the main README:
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ openwebui-installer status     # Show current status
 
 ## 🧑‍💻 Development and Testing
 
-Install the development requirements and Qt dependencies before running tests.
+Install the development requirements (which include `python-dotenv`) and Qt dependencies before running tests.
 
 ```bash
-pip install -r requirements-dev.txt
+pip install -r requirements-dev.txt  # installs python-dotenv for pytest
 sudo apt-get update && sudo apt-get install -y libegl1
 QT_QPA_PLATFORM=offscreen pytest tests/
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,9 @@ bandit>=1.7.0
 build>=0.10.0
 twine>=4.0.0
 
+# Needed for tests and local runs to load environment variables
+python-dotenv>=1.0.0
+
 # Additional development tools
 pre-commit>=3.0.0
 coverage>=7.0.0


### PR DESCRIPTION
## Summary
- add python-dotenv to requirements-dev.txt
- document python-dotenv installation in README
- clarify dev setup steps in GETTING_STARTED
- note dependency installation in DEV_ENVIRONMENT guide

## Testing
- `pytest -q` *(fails: InstallerError: Failed to pull Ollama model test-model)*

------
https://chatgpt.com/codex/tasks/task_e_685cf07194b88326ab6f69c0d6e5ab72