### PR TITLE
Restrict installer to macOS

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -159,11 +159,11 @@ class Installer:
         if self.verbose:
             logger.info("Validating system requirements")
 
-        # Check supported operating systems (macOS and Linux)
+        # Check supported operating systems (currently only macOS)
         system = platform.system()
-        if system not in ("Darwin", "Linux"):
+        if system != "Darwin":
             raise SystemRequirementsError(
-                "This installer supports macOS and Linux. Windows support is planned for Phase 4."
+                "This installer currently supports only macOS"
             )
 
         # Check Python version (aligned with setup.py)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -48,8 +48,8 @@ class TestInstallerSuite:
 
     def test_check_system_requirements_wrong_os(self, installer, mocker):
         """Test that system requirements check fails on a non-macOS system."""
-        mocker.patch("platform.system", return_value="Windows")
-        with pytest.raises(SystemRequirementsError, match="This installer supports macOS and Linux. Windows support is planned for Phase 4."):
+        mocker.patch("platform.system", return_value="Linux")
+        with pytest.raises(SystemRequirementsError, match="This installer currently supports only macOS"):
             installer._check_system_requirements()
 
     def test_check_system_requirements_wrong_python(self, installer, mocker):


### PR DESCRIPTION
## Summary
- restrict installer OS check to macOS only
- update failing OS test message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and test assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cf069145c8326a3c512136d001a3b