### PR TITLE
Remove outdated merge script references

### DIFF
--- a/BRANCH_ANALYSIS_FIXES.md
+++ b/BRANCH_ANALYSIS_FIXES.md
@@ -3866,7 +3866,7 @@ run_integration_tests() {
 1.  Create `scripts/lib/integration_tester.sh` to house comprehensive integration tests.
 2.  Implement distinct test suites (e.g., CLI, installer logic, Swift app build/basic run).
 3.  Use `git worktree` to create isolated environments for testing a branch.
-4.  Integrate this into `post_merge_validation.sh` as a critical step.
+4.  Integrate this into the CI workflow as a critical step.
 5.  Add environment checks (e.g., for `xcodebuild`) to skip irrelevant tests gracefully.
 6.  Expand the number and depth of runtime tests for Python and Swift components.
 

--- a/BRANCH_ANALYSIS_IMPROVEMENTS.md
+++ b/BRANCH_ANALYSIS_IMPROVEMENTS.md
@@ -2648,7 +2648,7 @@ finalize_test_report() {
 
 ### Files to Modify
 - Create `scripts/utils/integration_testing.sh`
-- Update `post_merge_validation.sh` to include integration tests
+- Integrate these tests into the CI workflow
 - Add integration test configuration options
 
 ### Validation

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -234,11 +234,9 @@ git push origin BRANCH_NAME
 
 ### Available Tools
 - `.github/workflows/branch-cleanup.yml` - Automated branch cleanup
-- `scripts/auto_merge_safe.sh` - Automatically merges branches prefixed with `safe/` into the target branch.
-  - Usage: `./scripts/auto_merge_safe.sh` merges all safe branches into `main` by default.
-  - Or: `scripts/auto_merge_safe.sh -b main BRANCH_NAME...` for explicit control.
+- `.github/workflows/auto-pr-merge.yml` - Automatically merges pull requests once checks pass
 - `scripts/enhanced_branch_analyzer.sh` - Detailed branch categorization
-- `scripts/post_merge_validation.sh` - Post-merge validation and testing
+- `.github/workflows/ci.yml` - Post-merge validation and testing
 
 ### Usage Examples
 
@@ -249,7 +247,7 @@ gh workflow run branch-cleanup.yml
 
 # Manual merge with validation
 git merge origin/BRANCH_NAME
-./scripts/post_merge_validation.sh
+gh workflow run ci.yml
 
 # Manual conflict resolution
 ./scripts/manual_merge_branch.sh BRANCH_NAME

--- a/BRANCH_MERGE_SUMMARY.md
+++ b/BRANCH_MERGE_SUMMARY.md
@@ -165,10 +165,10 @@ If direct branch removal is required, run:
 git push origin --delete BRANCH_NAME
 ```
 
-### 🔧 Merge Scripts  
+### 🔧 Merge Scripts
 - `scripts/manual_merge_branch.sh` - Manual conflict resolution helper
 - `scripts/merge_critical_branches.sh` - Intelligent merge for critical branches
-- `scripts/post_merge_validation.sh` - Post-merge testing and validation
+- `.github/workflows/ci.yml` - Post-merge testing and validation pipeline
 
 ### 📊 Generated Reports
 - `.branch-analysis/review-20250623_143321/systematic_review_report.md` - Full analysis

--- a/repo-restructure-plan/REPO_RESTRUCTURE_PLAN.md
+++ b/repo-restructure-plan/REPO_RESTRUCTURE_PLAN.md
@@ -83,13 +83,13 @@ openwebuiinstaller/
 REMOVE/PRIVATE:
 ├── .branch-analysis/ (entire directory)
 ├── scripts/
-│   ├── auto_merge_safe.sh (retained as a public utility)
 │   ├── branch_maintenance.sh
 │   ├── enhanced_branch_analyzer.sh
 │   ├── merge_critical_branches.sh
 │   ├── merge_safe_branches.sh
-│   ├── post_merge_validation.sh
 │   └── systematic_branch_review.sh
+├── .github/workflows/auto-pr-merge.yml
+├── .github/workflows/ci.yml
 ├── smart_merge.sh
 ├── BRANCH_ANALYSIS_FIXES.md
 ├── BRANCH_ANALYSIS_IMPROVEMENTS.md

--- a/repo-restructure-plan/restructure-repo.sh
+++ b/repo-restructure-plan/restructure-repo.sh
@@ -75,13 +75,13 @@ main() {
     cat > "${BACKUP_DIR}/files_to_move.txt" << 'EOF'
 # Branch Analysis and Management
 .branch-analysis/
-# auto_merge_safe.sh is retained publicly
-# scripts/auto_merge_safe.sh
+# auto-pr-merge workflow is public
+.github/workflows/auto-pr-merge.yml
 scripts/branch_maintenance.sh
 scripts/enhanced_branch_analyzer.sh
 scripts/merge_critical_branches.sh
 scripts/merge_safe_branches.sh
-scripts/post_merge_validation.sh
+.github/workflows/ci.yml
 scripts/systematic_branch_review.sh
 smart_merge.sh
 BRANCH_ANALYSIS_FIXES.md


### PR DESCRIPTION
## Summary
- document the `auto-pr-merge` workflow instead of `auto_merge_safe.sh`
- point post-merge instructions to `ci.yml`
- clean up restructure plan scripts and docs accordingly

## Testing
- `pytest -q` *(fails: InstallerError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685d0d248ca08326806289b71e8f2245