### PR TITLE
Fix Homebrew formula version and sha256

### DIFF
--- a/homebrew-tap/Formula/openwebui-installer.rb
+++ b/homebrew-tap/Formula/openwebui-installer.rb
@@ -6,8 +6,7 @@ class OpenwebuiInstaller < Formula
   desc "A macOS installer for Open WebUI with native Ollama integration"
   homepage "https://github.com/open-webui/openwebui-installer"
   url "https://github.com/open-webui/openwebui-installer/archive/refs/tags/v#{version}.tar.gz"
-  sha256 "placeholder" # Will be updated by CI
-  version "0.1.0"
+  sha256 "REPLACE_WITH_ACTUAL_SHA256_HASH" # Updated by CI during release
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
## Summary
- remove duplicate version declaration from Homebrew formula
- note that the `sha256` field is replaced by CI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d0d1d7750832692f575e7428f4602