### PR TITLE
Fix CLI subcommand defaults

### DIFF
--- a/openwebui_installer/cli.py
+++ b/openwebui_installer/cli.py
@@ -32,14 +32,19 @@ def validate_system(runtime: str, verbose: bool = False) -> bool:
 
 @click.group()
 @click.version_option(version=__version__)
-@click.option('--runtime', type=click.Choice(['docker', 'podman']), default='docker', help='Container runtime to use')
+@click.option(
+    "--runtime",
+    type=click.Choice(["docker", "podman"]),
+    default="docker",
+    help="Container runtime to use",
+)
 @click.option("--verbose", is_flag=True, help="Enable verbose output")
 @click.pass_context
 def cli(ctx, runtime, verbose):
     """Open WebUI Installer - Install and manage Open WebUI with Ollama integration."""
     ctx.ensure_object(dict)
-    ctx.obj['runtime'] = runtime
-    ctx.obj['verbose'] = verbose
+    ctx.obj["runtime"] = runtime
+    ctx.obj["verbose"] = verbose
 
     if verbose:
         logging.basicConfig(level=logging.INFO)
@@ -55,8 +60,8 @@ def cli(ctx, runtime, verbose):
 def install(ctx, model: str, port: int, force: bool, image: Optional[str]):
     """Install Open WebUI and configure Ollama integration."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI install command invoked with model: %s, port: %d", model, port)
@@ -78,7 +83,7 @@ def install(ctx, model: str, port: int, force: bool, image: Optional[str]):
         console.print(f"\nOpen WebUI is now available at: http://localhost:{port}")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Install command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -93,8 +98,8 @@ def uninstall(ctx):
         return
 
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI uninstall command invoked")
@@ -112,7 +117,7 @@ def uninstall(ctx):
         console.print("[green]✓[/green] Uninstallation complete!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Uninstall command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -123,8 +128,8 @@ def uninstall(ctx):
 def status(ctx):
     """Check Open WebUI installation status."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI status command invoked")
@@ -132,7 +137,7 @@ def status(ctx):
         with Installer(runtime=runtime, verbose=verbose) as installer:
             status = installer.get_status()
 
-        if status['installed']:
+        if status["installed"]:
             console.print("[green]✓[/green] Open WebUI is installed")
             console.print(f"Version: {status['version']}")
             console.print(f"Port: {status['port']}")
@@ -142,7 +147,7 @@ def status(ctx):
             console.print("[yellow]![/yellow] Open WebUI is not installed")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Status command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -153,8 +158,8 @@ def status(ctx):
 def start(ctx):
     """Start Open WebUI container."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI start command invoked")
@@ -172,7 +177,7 @@ def start(ctx):
         console.print("[green]✓[/green] Open WebUI started!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Start command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -183,8 +188,8 @@ def start(ctx):
 def stop(ctx):
     """Stop Open WebUI container."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI stop command invoked")
@@ -202,7 +207,7 @@ def stop(ctx):
         console.print("[green]✓[/green] Open WebUI stopped!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Stop command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -213,8 +218,8 @@ def stop(ctx):
 def restart(ctx):
     """Restart Open WebUI container."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI restart command invoked")
@@ -232,7 +237,7 @@ def restart(ctx):
         console.print("[green]✓[/green] Open WebUI restarted!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Restart command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -243,8 +248,8 @@ def restart(ctx):
 def update(ctx):
     """Update Open WebUI to the latest version."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI update command invoked")
@@ -262,7 +267,7 @@ def update(ctx):
         console.print("[green]✓[/green] Open WebUI updated!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Update command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -275,8 +280,8 @@ def update(ctx):
 def logs(ctx, lines: int, follow: bool):
     """Show Open WebUI container logs."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI logs command invoked with lines: %d, follow: %s", lines, follow)
@@ -285,7 +290,7 @@ def logs(ctx, lines: int, follow: bool):
             installer.show_logs(lines=lines, follow=follow)
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Logs command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)
@@ -297,8 +302,8 @@ def logs(ctx, lines: int, follow: bool):
 def autostart(ctx, enable: bool):
     """Configure Open WebUI to start automatically on boot (macOS only)."""
     try:
-        runtime = ctx.obj['runtime']
-        verbose = ctx.obj.get('verbose', False)
+        runtime = (ctx.obj or {}).get("runtime", "docker")
+        verbose = (ctx.obj or {}).get("verbose", False)
 
         if verbose:
             logger.info("CLI autostart command invoked with enable: %s", enable)
@@ -312,7 +317,7 @@ def autostart(ctx, enable: bool):
                 console.print("[green]✓[/green] Autostart disabled!")
 
     except Exception as e:
-        if ctx.obj.get('verbose', False):
+        if (ctx.obj or {}).get("verbose", False):
             logger.error("Autostart command failed: %s", str(e))
         console.print(f"[red]Error:[/red] {str(e)}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- allow CLI subcommands to run without parent group
- default `runtime` to docker and `verbose` to False when ctx is absent

## Testing
- `black openwebui_installer/cli.py --line-length 100`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_685d278c2fa48326b4d66dec486cd20c