### PR TITLE
Align ollama pull invocation

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -113,6 +113,7 @@ class TestInstallerSuite:
         installer.docker_client.images.pull.assert_called_with(installer.webui_image)
         mock_subprocess_run.assert_called_with(
             ["ollama", "pull", "test-model"],
+            check=True,
             capture_output=True,
             text=True,
             timeout=300,
@@ -315,6 +316,7 @@ class TestInstallerSuite:
         # Ensure subprocess.run was called with the correct model
         mock_subprocess_run.assert_called_with(
             ["ollama", "pull", model_name],
+            check=True,
             capture_output=True,
             text=True,
             timeout=300,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -120,7 +120,13 @@ def test_installation_workflow(installer):
         installer.docker_client.images.pull.assert_called_once_with(installer.webui_image)
 
         # Verify Ollama model was pulled
-        mock_run.assert_called_once_with(["ollama", "pull", "llama2"], check=True, timeout=300)
+        mock_run.assert_called_once_with(
+            ["ollama", "pull", "llama2"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
 
 def test_uninstall_workflow(installer):
     """Test uninstall workflow"""


### PR DESCRIPTION
## Summary
- make integration test expect capture_output/text
- check `subprocess.run` call for `install` tests

## Testing
- `pytest -vv tests/test_installer.py::TestInstallerSuite::test_pull_ollama_model_failure`


------
https://chatgpt.com/codex/tasks/task_e_685d27941a088326bcb0d63498e43b25