### PR TITLE
Call system checks in install

### DIFF
--- a/openwebui_installer/installer.py
+++ b/openwebui_installer/installer.py
@@ -337,6 +337,9 @@ class Installer:
             if self.verbose:
                 logger.info("Starting installation")
 
+            # Validate prerequisites before proceeding
+            self._check_system_requirements()
+
             # Check if already installed
             if not force and self.get_status()["installed"]:
                 raise InstallerError("Open WebUI is already installed. Use --force to reinstall.")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -25,7 +25,7 @@ def installer(tmp_path, mocker):  # Added mocker
     mock_docker_client = MagicMock()
     mocker.patch("docker.from_env", return_value=mock_docker_client)
 
-    installer_instance = Installer()
+    installer_instance = Installer(verbose=True)
     installer_instance.config_dir = str(config_dir)
     # Ensure the mock was effective
     assert installer_instance.docker_client == mock_docker_client
@@ -113,6 +113,7 @@ class TestInstallerSuite:
         installer.docker_client.images.pull.assert_called_with(installer.webui_image)
         mock_subprocess_run.assert_called_with(
             ["ollama", "pull", "test-model"],
+            check=True,
             capture_output=True,
             text=True,
             timeout=300,
@@ -168,6 +169,7 @@ class TestInstallerSuite:
 
     def test_install_stops_if_already_installed_without_force(self, installer, mocker):
         """Test that installation stops if already installed and force=False."""
+        mocker.patch.object(installer, "_check_system_requirements")
         mocker.patch.object(installer, "get_status", return_value={"installed": True})
         with pytest.raises(
             InstallerError, match="Open WebUI is already installed. Use --force to reinstall."
@@ -224,7 +226,7 @@ class TestInstallerSuite:
 
     def test_get_status_installed_and_running(self, installer, mocker):
         """Test get_status reports correctly when installed and the container is running."""
-        mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
+        mock_file_content = '{"image": "1.0", "port": 8080, "model": "test-model"}'
         mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
         mocker.patch("os.path.exists", return_value=True)
 
@@ -240,7 +242,7 @@ class TestInstallerSuite:
 
     def test_get_status_installed_not_running(self, installer, mocker):
         """Test get_status reports correctly when installed but the container is not running."""
-        mock_file_content = '{"version": "1.0", "port": 8080, "model": "test-model"}'
+        mock_file_content = '{"image": "1.0", "port": 8080, "model": "test-model"}'
         mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
         mocker.patch("os.path.exists", return_value=True)
 
@@ -315,6 +317,7 @@ class TestInstallerSuite:
         # Ensure subprocess.run was called with the correct model
         mock_subprocess_run.assert_called_with(
             ["ollama", "pull", model_name],
+            check=True,
             capture_output=True,
             text=True,
             timeout=300,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -120,7 +120,13 @@ def test_installation_workflow(installer):
         installer.docker_client.images.pull.assert_called_once_with(installer.webui_image)
 
         # Verify Ollama model was pulled
-        mock_run.assert_called_once_with(["ollama", "pull", "llama2"], check=True, timeout=300)
+        mock_run.assert_called_once_with(
+            ["ollama", "pull", "llama2"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
 
 def test_uninstall_workflow(installer):
     """Test uninstall workflow"""
@@ -156,7 +162,7 @@ def test_status_check(installer):
     with patch('os.path.exists', return_value=True), \
          patch('builtins.open', create=True) as mock_open:
 
-        mock_open.return_value.__enter__.return_value.read.return_value = '{"version": "0.1.0", "port": 3000, "model": "llama2"}'
+        mock_open.return_value.__enter__.return_value.read.return_value = '{"image": "0.1.0", "port": 3000, "model": "llama2"}'
 
         with patch.object(installer.docker_client.containers, 'get', side_effect=docker.errors.NotFound("Container not found")):
             status = installer.get_status()


### PR DESCRIPTION
## Summary
- ensure installation validates system prerequisites
- adapt installer test fixture for verbose mode
- adjust CLI tests to use main command group and update log checks
- update integration tests for new ollama call pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d278ee0a48326be6f7174e80f1ef2